### PR TITLE
Show average weekly workouts in mesocycle cards

### DIFF
--- a/src/Pages/MesocyclePage/Components/MesocycleList/MesocycleList.js
+++ b/src/Pages/MesocyclePage/Components/MesocycleList/MesocycleList.js
@@ -42,7 +42,23 @@ const MesocycleList = ({ program_id, start_date, refreshKey, refresh }) => {
         [program_id]
       );
 
-      const enriched = enrichMesocycles(cycles);
+      const workoutCounts = await db.getAllAsync(
+        `SELECT m.mesocycle_id, COUNT(w.workout_id) AS workout_count
+         FROM Mesocycle m
+         LEFT JOIN Microcycle mc ON mc.mesocycle_id = m.mesocycle_id
+         LEFT JOIN Day d ON d.microcycle_id = mc.microcycle_id
+         LEFT JOIN Workout w ON w.day_id = d.day_id
+         WHERE m.program_id = ?
+         GROUP BY m.mesocycle_id;`,
+        [program_id]
+      );
+
+      const workoutCountMap = workoutCounts.reduce((acc, row) => {
+        acc[row.mesocycle_id] = row.workout_count ?? 0;
+        return acc;
+      }, {});
+
+      const enriched = enrichMesocycles(cycles, workoutCountMap);
       setMesocycles(enriched);
 
     } catch (error) {
@@ -52,7 +68,7 @@ const MesocycleList = ({ program_id, start_date, refreshKey, refresh }) => {
     }
   };
 
-  const enrichMesocycles = (cycles) => {
+  const enrichMesocycles = (cycles, workoutCountMap) => {
     let weekOffset = 0;
 
     return cycles.map(cycle => {
@@ -64,10 +80,14 @@ const MesocycleList = ({ program_id, start_date, refreshKey, refresh }) => {
 
       weekOffset += cycle.weeks;
 
+      const workoutCount = workoutCountMap[cycle.mesocycle_id] ?? 0;
+      const averageWeeklyWorkouts = cycle.weeks > 0 ? workoutCount / cycle.weeks : 0;
+
       return {
         ...cycle,
         period_start: formatDate(start),
         period_end: formatDate(end),
+        average_weekly_workouts: averageWeeklyWorkouts,
         weightlifts: 0,
         cardio: 0,
         other: 0,
@@ -188,7 +208,9 @@ const MesocycleList = ({ program_id, start_date, refreshKey, refresh }) => {
             </View>
 
             <View style={[styles.frequency, {flex: 1, justifyContent: "flex-end" }]}>
-
+              <ThemedText setColor={theme.textInverted}>
+                Avg. weekly workouts: {item.average_weekly_workouts.toFixed(1)}
+              </ThemedText>
 
             </View>
 


### PR DESCRIPTION
### Motivation
- Provide a quick at-a-glance metric for each mesocycle on the program overview so users can see the average number of weekly workouts per cycle.

### Description
- Query mesocycle-level workout counts with a SQL aggregation joining `Mesocycle -> Microcycle -> Day -> Workout` in `MesocycleList` and map counts by `mesocycle_id`.
- Extend `enrichMesocycles` to accept the workout count map and compute `average_weekly_workouts = workout_count / weeks` using a zero-safe fallback.
- Add the `average_weekly_workouts` field to the enriched mesocycle objects and render it in each cycle card as `Avg. weekly workouts: X.X` with one decimal precision.
- Changes made in `src/Pages/MesocyclePage/Components/MesocycleList/MesocycleList.js`.

### Testing
- Attempted to run the app with `npm run web` to validate rendering, but it failed in this environment due to an Expo CLI network fetch error (`TypeError: fetch failed`).
- No unit tests were present for this component, and no further automated tests ran in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff16a3634832c87d46144f1cc56b0)