### PR TITLE
[codex] add program cloud sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Keep the root guide short and place domain-specific rules in closer `AGENTS.md` 
 
 ## Versioning And Changelog
 
-- After creating or switching to a work branch, use `npm run version:auto`.
+- After creating or switching to a work branch, use `npm run version:auto` before making further version edits so the branch version is derived from its base commit.
 - Use `npm run version:status` whenever you need to verify the current branch/version state.
 - Prefer branch names like `feat/...`, `fix/...`, or `release/x.y.z`.
 - Use `npm run release:prepare -- <version>` for stable releases.

--- a/App.js
+++ b/App.js
@@ -25,6 +25,7 @@ import { ThemedText, ThemedView } from './src/Resources/ThemedComponents';
 import { locationService } from "./src/Services";
 import { AuthProvider, useAuth } from './src/Contexts/AuthContext';
 import ExerciseLibrarySync from "./src/Sync/ExerciseLibrarySync";
+import ProgramSync from "./src/Sync/ProgramSync";
 
 import * as SQLite from 'expo-sqlite';
 
@@ -133,6 +134,7 @@ export default function App() {
         onInit={initializeDatabase}
         options={{ useNewConnection: false }}>
         <AuthProvider>
+          <ProgramSync />
           <ExerciseLibrarySync />
           <RootNavigator />
         </AuthProvider>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ All changes to the project are logged here.
 
 All changes to the project are logged here.
 
+
+
+All changes to the project are logged here.
+
 ## [Unreleased]
 ### Changed
-- Describe upcoming changes here.
+- Removed `program_id` from the local `Microcycle` table and added a safe migration that rebuilds the table without changing existing `microcycle_id` relationships.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to the project are logged here.
 ## [Unreleased]
 ### Changed
 - Renamed the local `Workout` table to `Workout_Type_Instance`, added a local `Workout_Type` table, and introduced a safe migration that preserves existing workout rows while backfilling `workout_type`.
+- Aligned the local `Exercise` catalog with the cloud naming model, moved muscle-group counts to runtime calculation, and safely migrated `Exercise_Instance` to `exercise_instance_id` and `workout_type_instance_id` without breaking existing set relationships.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,29 @@
 
 All changes to the project are logged here.
 
-
-
-All changes to the project are logged here.
-
-
-
-All changes to the project are logged here.
-
 ## [Unreleased]
 ### Changed
+- Renamed the local `Workout` table to `Workout_Type_Instance`, added a local `Workout_Type` table, and introduced a safe migration that preserves existing workout rows while backfilling `workout_type`.
+
+---
+
+## [0.4.1] - 2026-04-09
+### Changed
 - Removed `program_id` from the local `Microcycle` table and added a safe migration that rebuilds the table without changing existing `microcycle_id` relationships.
+
+---
+
+## [0.4.0] - 2026-04-07
+### Added
+- Branch-based versioning scripts for branch, sync, status, and release workflows.
+### Changed
+- `CHANGELOG.md` now keeps an `Unreleased` section ahead of versioned release entries.
 
 ---
 
 ## [0.3.0] - 2026-03-25
 ### Added
 - Login page
-
 
 ## [0.2.2.2] - 2026-03-25
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to the project are logged here.
 ### Changed
 - Renamed the local `Workout` table to `Workout_Type_Instance`, added a local `Workout_Type` table, and introduced a safe migration that preserves existing workout rows while backfilling `workout_type`.
 - Aligned the local `Exercise` catalog with the cloud naming model, moved muscle-group counts to runtime calculation, and safely migrated `Exercise_Instance` to `exercise_instance_id` and `workout_type_instance_id` without breaking existing set relationships.
+- Renamed the local `Sets` table to `Set` and safely migrated its `exercise_id` relation to `exercise_instance_id` without breaking existing set rows.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All changes to the project are logged here.
 
+
+
+All changes to the project are logged here.
+
 ## [Unreleased]
 ### Changed
 - Renamed the local `Workout` table to `Workout_Type_Instance`, added a local `Workout_Type` table, and introduced a safe migration that preserves existing workout rows while backfilling `workout_type`.
 - Aligned the local `Exercise` catalog with the cloud naming model, moved muscle-group counts to runtime calculation, and safely migrated `Exercise_Instance` to `exercise_instance_id` and `workout_type_instance_id` without breaking existing set relationships.
 - Renamed the local `Sets` table to `Set` and safely migrated its `exercise_id` relation to `exercise_instance_id` without breaking existing set rows.
+- Added the first `Program` cloud sync flow with local cloud-id tracking, dirty-state sync flags, remote delete queueing, and an app-level sync runner that uploads local program changes and pulls remote-only programs.
+- Normalized `Program.start_date` between local SQLite `dd.MM.yyyy` strings and cloud PostgreSQL `date` values to avoid sync failures and mixed local date formats.
 
 ---
 

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "FitVen",
     "slug": "programapp",
-    "version": "0.4.1-fix-remove-microcycle-program-id.1",
+    "version": "0.4.2-fix-workout-type-instance-local-schema.1",
     "orientation": "portrait",
     "icon": "./assets/icon_v1.0.png",
     "userInterfaceStyle": "dark",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "FitVen",
     "slug": "programapp",
-    "version": "0.4.4-fix-set-schema-alignment.1",
+    "version": "0.5.0-feat-program-cloud-sync.1",
     "orientation": "portrait",
     "icon": "./assets/icon_v1.0.png",
     "userInterfaceStyle": "dark",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "FitVen",
     "slug": "programapp",
-    "version": "0.4.2-fix-workout-type-instance-local-schema.1",
+    "version": "0.4.3-fix-exercise-instance-schema-alignment.1",
     "orientation": "portrait",
     "icon": "./assets/icon_v1.0.png",
     "userInterfaceStyle": "dark",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "FitVen",
     "slug": "programapp",
-    "version": "0.4.3-fix-exercise-instance-schema-alignment.1",
+    "version": "0.4.4-fix-set-schema-alignment.1",
     "orientation": "portrait",
     "icon": "./assets/icon_v1.0.png",
     "userInterfaceStyle": "dark",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "FitVen",
     "slug": "programapp",
-    "version": "0.4.0-feat-versioning-workflow.1",
+    "version": "0.4.1-fix-remove-microcycle-program-id.1",
     "orientation": "portrait",
     "icon": "./assets/icon_v1.0.png",
     "userInterfaceStyle": "dark",

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,6 +7,7 @@
 - Reserve build number increments for real releases.
 - Keep `CHANGELOG.md` stable with an `Unreleased` section plus release entries.
 - Make versioning mostly automatic from the active branch.
+- Derive prerelease bumps from the committed base version of the current work branch.
 
 ## Branch Rules
 
@@ -18,7 +19,8 @@
 Examples:
 
 - `feat/program-calendar` from stable `0.3.1` becomes `0.4.0-feat-program-calendar.1`
-- `fix/set-counter` from stable `0.3.1` becomes `0.3.2-fix-set-counter.1`
+- `fix/set-counter` from committed `0.3.1` becomes `0.3.2-fix-set-counter.1`
+- `fix/workout-type-instance` from committed `0.4.1` becomes `0.4.2-fix-workout-type-instance.1`
 - `release/0.4.0` becomes `0.4.0`
 
 If a branch name does not match the convention, use:
@@ -27,13 +29,17 @@ If a branch name does not match the convention, use:
 npm run version:branch -- minor
 ```
 
+If you rename a work branch after it has already been versioned, or you want to recalculate from a specific committed base, rerun the command with `--base-ref <ref>`.
+
 ## Commands
 
 ```bash
 npm run version:status
 npm run version:auto
+npm run version:auto -- --base-ref master
 npm run version:branch
 npm run version:branch -- patch
+npm run version:branch -- --base-ref master
 npm run version:branch -- feat/example dry-run
 npm run release:prepare -- 0.4.0 dry-run
 npm run version:sync -- 0.4.0 skip-changelog
@@ -52,6 +58,7 @@ npm run version:sync -- 0.4.0 skip-changelog
 
 - Reads the current branch name
 - Uses branch rules automatically
+- Uses committed `HEAD` as the default base ref, so running it right after branching derives the next prerelease from the branch base commit
 - Runs branch prerelease logic on `feat/...`, `fix/...`, and similar work branches
 - Runs release logic on `release/x.y.z`
 - Refuses to work on `master` and `main`
@@ -61,6 +68,7 @@ npm run version:sync -- 0.4.0 skip-changelog
 - Updates `package.json > version`
 - Updates `app.json > expo.version`
 - Ensures `CHANGELOG.md` contains `## [Unreleased]`
+- Uses committed `HEAD` as the default base ref unless `--base-ref <ref>` is supplied
 - Does not increment `android.versionCode`
 - Does not increment `ios.buildNumber`
 
@@ -75,7 +83,7 @@ npm run version:sync -- 0.4.0 skip-changelog
 ## Recommended Workflow
 
 1. Create a branch with a meaningful prefix like `feat/...`, `fix/...`, or `release/x.y.z`.
-2. Run `npm run version:auto`.
+2. Run `npm run version:auto` immediately after branching.
 3. Use `npm run version:status` whenever you want to verify the current state.
 4. Do the work.
 5. Replace the placeholder text in `CHANGELOG.md` before shipping.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "programapp",
-  "version": "0.4.1-fix-remove-microcycle-program-id.1",
+  "version": "0.4.2-fix-workout-type-instance-local-schema.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client --scheme exp+programapp-dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "programapp",
-  "version": "0.4.3-fix-exercise-instance-schema-alignment.1",
+  "version": "0.4.4-fix-set-schema-alignment.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client --scheme exp+programapp-dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "programapp",
-  "version": "0.4.0-feat-versioning-workflow.1",
+  "version": "0.4.1-fix-remove-microcycle-program-id.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client --scheme exp+programapp-dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "programapp",
-  "version": "0.4.2-fix-workout-type-instance-local-schema.1",
+  "version": "0.4.3-fix-exercise-instance-schema-alignment.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client --scheme exp+programapp-dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "programapp",
-  "version": "0.4.4-fix-set-schema-alignment.1",
+  "version": "0.5.0-feat-program-cloud-sync.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client --scheme exp+programapp-dev",

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -125,7 +125,8 @@ function parseOptions(tokens) {
   const parsed = {
     branchName: null,
     bump: null,
-    baseRef: "master",
+    baseRef: "HEAD",
+    baseRefProvided: false,
     dryRun: false,
     skipChangelog: false,
     positionals: [],
@@ -156,6 +157,7 @@ function parseOptions(tokens) {
 
     if (token.startsWith("base-ref=")) {
       parsed.baseRef = token.slice("base-ref=".length);
+      parsed.baseRefProvided = true;
       continue;
     }
 
@@ -173,6 +175,7 @@ function parseOptions(tokens) {
 
     if (token === "--base-ref") {
       parsed.baseRef = tokens[index + 1];
+      parsed.baseRefProvided = true;
       index += 1;
       continue;
     }
@@ -246,9 +249,14 @@ function prepareBranchVersioning(currentOptions) {
 
   const prereleaseSuffix = `${sanitizeBranchName(branchName)}.1`;
   const currentPackageVersion = readJson(packageJsonPath).version;
-  const targetVersion = String(currentPackageVersion).endsWith(`-${prereleaseSuffix}`)
-    ? String(currentPackageVersion)
-    : `${bumpStableVersion(readStableVersionFromRef(currentOptions.baseRef), inferredBump)}-${prereleaseSuffix}`;
+  const computedTargetVersion = `${bumpStableVersion(
+    readStableVersionFromRef(currentOptions.baseRef),
+    inferredBump
+  )}-${prereleaseSuffix}`;
+  const targetVersion =
+    String(currentPackageVersion).endsWith(`-${prereleaseSuffix}`) && !currentOptions.baseRefProvided
+      ? String(currentPackageVersion)
+      : computedTargetVersion;
 
   return buildVersioningSummary({
     mode: "branch",
@@ -405,9 +413,14 @@ function printStatus(currentOptions) {
   }
 
   const prereleaseSuffix = `${sanitizeBranchName(branchName)}.1`;
-  const expectedVersion = String(packageVersion).endsWith(`-${prereleaseSuffix}`)
-    ? packageVersion
-    : `${bumpStableVersion(readStableVersionFromRef(currentOptions.baseRef), inferredBump)}-${prereleaseSuffix}`;
+  const computedExpectedVersion = `${bumpStableVersion(
+    readStableVersionFromRef(currentOptions.baseRef),
+    inferredBump
+  )}-${prereleaseSuffix}`;
+  const expectedVersion =
+    String(packageVersion).endsWith(`-${prereleaseSuffix}`) && !currentOptions.baseRefProvided
+      ? packageVersion
+      : computedExpectedVersion;
   console.log(`Expected version from branch: ${expectedVersion}`);
   console.log(
     `Recommended action: ${

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -22,6 +22,13 @@ This file applies to everything inside `src/`.
 - When moving or renaming files, update imports in the same change.
 - Reuse `Resources` and existing services/repositories before creating parallel patterns.
 
+## Sync Rules
+
+- Treat `Workout_Type_Instance` as the lowest-level cloud sync boundary for workout data.
+- Changes to `Set`, `Exercise_Instance`, or other workout-child rows should update local state immediately, but should not trigger direct cloud writes on their own.
+- Child-row changes should instead mark the owning `Workout_Type_Instance` as dirty so the full workout payload can be synced together later.
+- Prefer syncing workout-child data when the owning `Workout_Type_Instance` is completed or when an explicit higher-level workout sync runs.
+
 ## Related Guides
 
 - See `src/Pages/AGENTS.md` for UI-specific guidance.

--- a/src/Database/db.js
+++ b/src/Database/db.js
@@ -78,6 +78,56 @@ async function migrateWeightliftingTableNames(db) {
   }
 }
 
+async function migrateMicrocycleProgramIdRemoval(db) {
+  const microcycleColumns = await getTableColumns(db, "Microcycle");
+
+  if (
+    !microcycleColumns.length ||
+    !microcycleColumns.some((column) => column.name === "program_id")
+  ) {
+    return;
+  }
+
+  await db.execAsync("BEGIN IMMEDIATE;");
+
+  try {
+    await db.execAsync(`
+      DROP TABLE IF EXISTS Microcycle_next;
+
+      CREATE TABLE Microcycle_next (
+        microcycle_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        mesocycle_id INTEGER NOT NULL,
+        microcycle_number INTEGER NOT NULL,
+        focus TEXT DEFAULT "No focus",
+        done INTEGER NOT NULL DEFAULT 0
+      );
+
+      INSERT INTO Microcycle_next (
+        microcycle_id,
+        mesocycle_id,
+        microcycle_number,
+        focus,
+        done
+      )
+      SELECT
+        microcycle_id,
+        mesocycle_id,
+        microcycle_number,
+        focus,
+        done
+      FROM Microcycle;
+
+      DROP TABLE Microcycle;
+      ALTER TABLE Microcycle_next RENAME TO Microcycle;
+    `);
+
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+}
+
 async function repairWorkoutTrackingState(db) {
   await db.execAsync(`
     UPDATE Workout
@@ -193,6 +243,11 @@ export async function initializeDatabase(db) {
     ["done", "INTEGER NOT NULL DEFAULT 0"],
   ]);
 
+  await ensureTableColumns(db, "Microcycle", [
+    ["focus", 'TEXT DEFAULT "No focus"'],
+    ["done", "INTEGER NOT NULL DEFAULT 0"],
+  ]);
+  await migrateMicrocycleProgramIdRemoval(db);
   await ensureTableColumns(db, "Microcycle", [
     ["focus", 'TEXT DEFAULT "No focus"'],
     ["done", "INTEGER NOT NULL DEFAULT 0"],

--- a/src/Database/db.js
+++ b/src/Database/db.js
@@ -542,6 +542,14 @@ async function repairRunSetState(db) {
   `);
 }
 
+async function repairProgramDateFormats(db) {
+  await db.execAsync(`
+    UPDATE Program
+    SET start_date = substr(start_date, 9, 2) || '.' || substr(start_date, 6, 2) || '.' || substr(start_date, 1, 4)
+    WHERE start_date LIKE '____-__-__';
+  `);
+}
+
 export async function initializeDatabase(db) {
   await migrateWeightliftingTableNames(db);
   await migrateWorkoutTableName(db);
@@ -559,7 +567,9 @@ export async function initializeDatabase(db) {
   `);
 
   await ensureTableColumns(db, "Program", [
+    ["cloud_program_id", "INTEGER"],
     ["status", "TEXT NOT NULL DEFAULT 'NOT_STARTED'"],
+    ["needs_sync", "INTEGER NOT NULL DEFAULT 1"],
   ]);
 
   await ensureTableColumns(db, "Mesocycle", [
@@ -643,6 +653,7 @@ export async function initializeDatabase(db) {
   await repairWorkoutTrackingState(db);
   await repairStrengthTrainingState(db);
   await repairRunSetState(db);
+  await repairProgramDateFormats(db);
 
   await initializeWeightliftingData(db);
 

--- a/src/Database/db.js
+++ b/src/Database/db.js
@@ -14,15 +14,21 @@ const DEFAULT_WORKOUT_TYPES = [
   ["Run", "Run"],
 ];
 
+function quoteIdentifier(identifier) {
+  return `"${String(identifier).replace(/"/g, '""')}"`;
+}
+
 async function ensureColumnExists(db, tableName, columnName, columnDefinition) {
-  const columns = await db.getAllAsync(`PRAGMA table_info(${tableName});`);
+  const columns = await db.getAllAsync(
+    `PRAGMA table_info(${quoteIdentifier(tableName)});`
+  );
 
   if (columns.some((column) => column.name === columnName)) {
     return;
   }
 
   await db.execAsync(
-    `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnDefinition};`
+    `ALTER TABLE ${quoteIdentifier(tableName)} ADD COLUMN ${columnName} ${columnDefinition};`
   );
 }
 
@@ -33,7 +39,7 @@ async function ensureTableColumns(db, tableName, columns) {
 }
 
 async function getTableColumns(db, tableName) {
-  return db.getAllAsync(`PRAGMA table_info(${tableName});`);
+  return db.getAllAsync(`PRAGMA table_info(${quoteIdentifier(tableName)});`);
 }
 
 function hasColumn(columns, columnName) {
@@ -268,6 +274,100 @@ async function migrateExerciseInstanceSchema(db) {
   }
 }
 
+async function migrateSetSchema(db) {
+  const legacySetColumns = await getTableColumns(db, "Sets");
+  const setColumns = await getTableColumns(db, "Set");
+  const sourceTable = setColumns.length ? "Set" : legacySetColumns.length ? "Sets" : null;
+  const sourceColumns = setColumns.length ? setColumns : legacySetColumns;
+
+  if (!sourceTable || !sourceColumns.length) {
+    return;
+  }
+
+  const hasLegacyExerciseColumn = hasColumn(sourceColumns, "exercise_id");
+  const hasNewExerciseColumn = hasColumn(sourceColumns, "exercise_instance_id");
+
+  if (sourceTable === "Set" && !hasLegacyExerciseColumn && hasNewExerciseColumn) {
+    return;
+  }
+
+  const exerciseColumn = hasNewExerciseColumn
+    ? "exercise_instance_id"
+    : hasLegacyExerciseColumn
+      ? "exercise_id"
+      : null;
+
+  if (!exerciseColumn) {
+    return;
+  }
+
+  await db.execAsync("BEGIN IMMEDIATE;");
+
+  try {
+    await db.execAsync(`
+      DROP TABLE IF EXISTS "Set_next";
+
+      CREATE TABLE "Set_next" (
+        sets_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        set_number INTEGER NOT NULL,
+        exercise_instance_id INTEGER NOT NULL,
+        date TEXT,
+        personal_record INTEGER NOT NULL DEFAULT 0,
+        pause INTEGER,
+        rpe INTEGER,
+        weight INTEGER,
+        rm_percentage INTEGER,
+        reps INTEGER,
+        done INTEGER NOT NULL DEFAULT 0,
+        failed INTEGER NOT NULL DEFAULT 0,
+        amrap INTEGER NOT NULL DEFAULT 0,
+        note TEXT
+      );
+
+      INSERT INTO "Set_next" (
+        sets_id,
+        set_number,
+        exercise_instance_id,
+        date,
+        personal_record,
+        pause,
+        rpe,
+        weight,
+        rm_percentage,
+        reps,
+        done,
+        failed,
+        amrap,
+        note
+      )
+      SELECT
+        sets_id,
+        set_number,
+        ${exerciseColumn},
+        ${hasColumn(sourceColumns, "date") ? "date" : "NULL"},
+        ${hasColumn(sourceColumns, "personal_record") ? "COALESCE(personal_record, 0)" : "0"},
+        ${hasColumn(sourceColumns, "pause") ? "pause" : "NULL"},
+        ${hasColumn(sourceColumns, "rpe") ? "rpe" : "NULL"},
+        ${hasColumn(sourceColumns, "weight") ? "weight" : "NULL"},
+        ${hasColumn(sourceColumns, "rm_percentage") ? "rm_percentage" : "NULL"},
+        ${hasColumn(sourceColumns, "reps") ? "reps" : "NULL"},
+        ${hasColumn(sourceColumns, "done") ? "COALESCE(done, 0)" : "0"},
+        ${hasColumn(sourceColumns, "failed") ? "COALESCE(failed, 0)" : "0"},
+        ${hasColumn(sourceColumns, "amrap") ? "COALESCE(amrap, 0)" : "0"},
+        ${hasColumn(sourceColumns, "note") ? "note" : "NULL"}
+      FROM ${quoteIdentifier(sourceTable)};
+
+      DROP TABLE ${quoteIdentifier(sourceTable)};
+      ALTER TABLE "Set_next" RENAME TO "Set";
+    `);
+
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+}
+
 async function migrateMicrocycleProgramIdRemoval(db) {
   const microcycleColumns = await getTableColumns(db, "Microcycle");
 
@@ -392,9 +492,9 @@ async function repairStrengthTrainingState(db) {
     SET done = (
       NOT EXISTS (
         SELECT 1
-        FROM Sets
-        WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
-          AND Sets.done = 0
+        FROM "Set"
+        WHERE "Set".exercise_instance_id = Exercise_Instance.exercise_instance_id
+          AND "Set".done = 0
       )
     );
 
@@ -447,6 +547,7 @@ export async function initializeDatabase(db) {
   await migrateWorkoutTableName(db);
   await migrateExerciseCatalogSchema(db);
   await migrateExerciseInstanceSchema(db);
+  await migrateSetSchema(db);
 
   await db.execAsync(`
     ${programSchemaSql}
@@ -506,7 +607,7 @@ export async function initializeDatabase(db) {
     ["done", "INTEGER NOT NULL DEFAULT 0"],
   ]);
 
-  await ensureTableColumns(db, "Sets", [
+  await ensureTableColumns(db, "Set", [
     ["date", "TEXT"],
     ["personal_record", "INTEGER NOT NULL DEFAULT 0"],
     ["pause", "INTEGER"],
@@ -534,8 +635,8 @@ export async function initializeDatabase(db) {
     UPDATE Exercise_Instance
     SET sets = (
       SELECT COUNT(*)
-      FROM Sets
-      WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
+      FROM "Set"
+      WHERE "Set".exercise_instance_id = Exercise_Instance.exercise_instance_id
     );
   `);
 
@@ -569,7 +670,7 @@ export async function initializeDatabase(db) {
   /*
   await db.execAsync(`
     DROP TABLE IF EXISTS Program;
-    DROP TABLE IF EXISTS Sets;
+    DROP TABLE IF EXISTS "Set";
     DROP TABLE IF EXISTS Exercise;
     DROP TABLE IF EXISTS Exercise_Instance;
     DROP TABLE IF EXISTS Workout_Type_Instance;

--- a/src/Database/db.js
+++ b/src/Database/db.js
@@ -6,6 +6,14 @@ import {
 import { runningSchemaSql } from './schema/running';
 import { locationSchemaSql } from './schema/location';
 
+const DEFAULT_WORKOUT_TYPES = [
+  ["Resistance", "Resistance"],
+  ["Upperbody", "Upperbody"],
+  ["Legs", "Legs"],
+  ["StrengthTraining", "StrengthTraining"],
+  ["Run", "Run"],
+];
+
 async function ensureColumnExists(db, tableName, columnName, columnDefinition) {
   const columns = await db.getAllAsync(`PRAGMA table_info(${tableName});`);
 
@@ -78,6 +86,29 @@ async function migrateWeightliftingTableNames(db) {
   }
 }
 
+async function migrateWorkoutTableName(db) {
+  await db.execAsync("BEGIN IMMEDIATE;");
+
+  try {
+    const legacyWorkoutColumns = await getTableColumns(db, "Workout");
+    const workoutTypeInstanceColumns = await getTableColumns(
+      db,
+      "Workout_Type_Instance"
+    );
+
+    if (legacyWorkoutColumns.length && !workoutTypeInstanceColumns.length) {
+      await db.execAsync(`
+        ALTER TABLE Workout RENAME TO Workout_Type_Instance;
+      `);
+    }
+
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+}
+
 async function migrateMicrocycleProgramIdRemoval(db) {
   const microcycleColumns = await getTableColumns(db, "Microcycle");
 
@@ -128,9 +159,40 @@ async function migrateMicrocycleProgramIdRemoval(db) {
   }
 }
 
+async function backfillWorkoutTypeInstances(db) {
+  await db.execAsync(`
+    UPDATE Workout_Type_Instance
+    SET workout_type = label
+    WHERE TRIM(COALESCE(workout_type, '')) = ''
+      AND TRIM(COALESCE(label, '')) <> '';
+
+    UPDATE Workout_Type_Instance
+    SET label = workout_type
+    WHERE TRIM(COALESCE(label, '')) = ''
+      AND TRIM(COALESCE(workout_type, '')) <> '';
+  `);
+}
+
+async function initializeWorkoutTypes(db) {
+  for (const [name, displayName] of DEFAULT_WORKOUT_TYPES) {
+    await db.runAsync(
+      `INSERT OR IGNORE INTO Workout_Type (name, display_name)
+       VALUES (?, ?);`,
+      [name, displayName]
+    );
+  }
+
+  await db.execAsync(`
+    INSERT OR IGNORE INTO Workout_Type (name, display_name)
+    SELECT DISTINCT workout_type, workout_type
+    FROM Workout_Type_Instance
+    WHERE TRIM(COALESCE(workout_type, '')) <> '';
+  `);
+}
+
 async function repairWorkoutTrackingState(db) {
   await db.execAsync(`
-    UPDATE Workout
+    UPDATE Workout_Type_Instance
     SET is_active = 0
     WHERE is_active = 1
       AND (timer_start IS NULL OR done = 1);
@@ -138,7 +200,7 @@ async function repairWorkoutTrackingState(db) {
 
   const activeWorkouts = await db.getAllAsync(`
     SELECT workout_id
-    FROM Workout
+    FROM Workout_Type_Instance
     WHERE is_active = 1
       AND timer_start IS NOT NULL
       AND done = 0
@@ -153,7 +215,7 @@ async function repairWorkoutTrackingState(db) {
 
   for (const staleWorkout of staleWorkouts) {
     await db.runAsync(
-      `UPDATE Workout
+      `UPDATE Workout_Type_Instance
        SET is_active = 0
        WHERE workout_id = ?;`,
       [staleWorkout.workout_id]
@@ -177,18 +239,18 @@ async function repairStrengthTrainingState(db) {
       )
     );
 
-    UPDATE Workout
+    UPDATE Workout_Type_Instance
     SET done = (
       CASE
         WHEN EXISTS (
           SELECT 1
           FROM Run
-          WHERE Run.workout_id = Workout.workout_id
-        ) THEN Workout.done
+          WHERE Run.workout_id = Workout_Type_Instance.workout_id
+        ) THEN Workout_Type_Instance.done
         ELSE NOT EXISTS (
           SELECT 1
           FROM Exercise_Instance
-          WHERE Exercise_Instance.workout_id = Workout.workout_id
+          WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
             AND Exercise_Instance.done = 0
         )
       END
@@ -196,7 +258,7 @@ async function repairStrengthTrainingState(db) {
     WHERE EXISTS (
       SELECT 1
       FROM Exercise_Instance
-      WHERE Exercise_Instance.workout_id = Workout.workout_id
+      WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
     );
   `);
 }
@@ -223,6 +285,7 @@ async function repairRunSetState(db) {
 
 export async function initializeDatabase(db) {
   await migrateWeightliftingTableNames(db);
+  await migrateWorkoutTableName(db);
 
   await db.execAsync(`
     ${programSchemaSql}
@@ -257,7 +320,8 @@ export async function initializeDatabase(db) {
     ["done", "INTEGER NOT NULL DEFAULT 0"],
   ]);
 
-  await ensureTableColumns(db, "Workout", [
+  await ensureTableColumns(db, "Workout_Type_Instance", [
+    ["workout_type", "TEXT"],
     ["label", "TEXT"],
     ["done", "INTEGER NOT NULL DEFAULT 0"],
     ["is_active", "INTEGER DEFAULT 0"],
@@ -265,6 +329,11 @@ export async function initializeDatabase(db) {
     ["timer_start", "INTEGER"],
     ["elapsed_time", "INTEGER DEFAULT 0"],
   ]);
+  await ensureTableColumns(db, "Workout_Type", [
+    ["display_name", "TEXT"],
+  ]);
+  await backfillWorkoutTypeInstances(db);
+  await initializeWorkoutTypes(db);
 
   await ensureTableColumns(db, "Exercise", [
     ["primary_muscle_group_count", "INTEGER NOT NULL DEFAULT 0"],
@@ -318,7 +387,7 @@ export async function initializeDatabase(db) {
 
   /*
   await db.execAsync(`
-    ALTER TABLE Workout ADD COLUMN is_active INTEGER DEFAULT 0;
+    ALTER TABLE Workout_Type_Instance ADD COLUMN is_active INTEGER DEFAULT 0;
   `);
   */
 
@@ -343,7 +412,7 @@ export async function initializeDatabase(db) {
     DROP TABLE IF EXISTS Sets;
     DROP TABLE IF EXISTS Exercise;
     DROP TABLE IF EXISTS Exercise_Instance;
-    DROP TABLE IF EXISTS Workout;
+    DROP TABLE IF EXISTS Workout_Type_Instance;
     DROP TABLE IF EXISTS Day;
     DROP TABLE IF EXISTS Microcycle;
     DROP TABLE IF EXISTS Mesocycle;

--- a/src/Database/db.js
+++ b/src/Database/db.js
@@ -36,15 +36,20 @@ async function getTableColumns(db, tableName) {
   return db.getAllAsync(`PRAGMA table_info(${tableName});`);
 }
 
+function hasColumn(columns, columnName) {
+  return columns.some((column) => column.name === columnName);
+}
+
 function isExerciseCatalogTable(columns) {
   return (
-    columns.some((column) => column.name === "exercise_name") &&
-    !columns.some((column) => column.name === "workout_id")
+    (hasColumn(columns, "exercise_name") || hasColumn(columns, "name")) &&
+    !hasColumn(columns, "workout_id") &&
+    !hasColumn(columns, "workout_type_instance_id")
   );
 }
 
 function isExerciseInstanceTable(columns) {
-  return columns.some((column) => column.name === "workout_id");
+  return hasColumn(columns, "workout_id") || hasColumn(columns, "workout_type_instance_id");
 }
 
 async function migrateWeightliftingTableNames(db) {
@@ -101,6 +106,160 @@ async function migrateWorkoutTableName(db) {
         ALTER TABLE Workout RENAME TO Workout_Type_Instance;
       `);
     }
+
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+}
+
+async function migrateExerciseCatalogSchema(db) {
+  const exerciseColumns = await getTableColumns(db, "Exercise");
+
+  if (!exerciseColumns.length) {
+    return;
+  }
+
+  const hasLegacyNameColumn = hasColumn(exerciseColumns, "exercise_name");
+  const hasNameColumn = hasColumn(exerciseColumns, "name");
+  const hasNicknameColumn = hasColumn(exerciseColumns, "nickname");
+
+  if (
+    !hasLegacyNameColumn &&
+    hasNameColumn &&
+    hasNicknameColumn &&
+    !hasColumn(exerciseColumns, "primary_muscle_group_count") &&
+    !hasColumn(exerciseColumns, "secondary_muscle_group_count")
+  ) {
+    return;
+  }
+
+  const nameColumn = hasNameColumn ? "name" : hasLegacyNameColumn ? "exercise_name" : null;
+
+  if (!nameColumn) {
+    return;
+  }
+
+  await db.execAsync("BEGIN IMMEDIATE;");
+
+  try {
+    await db.execAsync(`
+      DROP TABLE IF EXISTS Exercise_next;
+
+      CREATE TABLE Exercise_next (
+        exercise_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        nickname TEXT
+      );
+
+      INSERT OR IGNORE INTO Exercise_next (
+        exercise_id,
+        name,
+        nickname
+      )
+      SELECT
+        exercise_id,
+        ${nameColumn},
+        ${hasNicknameColumn ? "nickname" : "NULL"}
+      FROM Exercise
+      WHERE TRIM(COALESCE(${nameColumn}, '')) <> ''
+      ORDER BY exercise_id ASC;
+
+      DROP TABLE Exercise;
+      ALTER TABLE Exercise_next RENAME TO Exercise;
+    `);
+
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+}
+
+async function migrateExerciseInstanceSchema(db) {
+  const exerciseInstanceColumns = await getTableColumns(db, "Exercise_Instance");
+
+  if (!exerciseInstanceColumns.length) {
+    return;
+  }
+
+  const hasLegacyIdColumn = hasColumn(exerciseInstanceColumns, "exercise_id");
+  const hasNewIdColumn = hasColumn(
+    exerciseInstanceColumns,
+    "exercise_instance_id"
+  );
+  const hasLegacyWorkoutColumn = hasColumn(
+    exerciseInstanceColumns,
+    "workout_id"
+  );
+  const hasNewWorkoutColumn = hasColumn(
+    exerciseInstanceColumns,
+    "workout_type_instance_id"
+  );
+
+  if (
+    !hasLegacyIdColumn &&
+    hasNewIdColumn &&
+    !hasLegacyWorkoutColumn &&
+    hasNewWorkoutColumn
+  ) {
+    return;
+  }
+
+  const idColumn = hasNewIdColumn
+    ? "exercise_instance_id"
+    : hasLegacyIdColumn
+      ? "exercise_id"
+      : null;
+  const workoutColumn = hasNewWorkoutColumn
+    ? "workout_type_instance_id"
+    : hasLegacyWorkoutColumn
+      ? "workout_id"
+      : null;
+
+  if (!idColumn || !workoutColumn) {
+    return;
+  }
+
+  await db.execAsync("BEGIN IMMEDIATE;");
+
+  try {
+    await db.execAsync(`
+      DROP TABLE IF EXISTS Exercise_Instance_next;
+
+      CREATE TABLE Exercise_Instance_next (
+        exercise_instance_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        workout_type_instance_id INTEGER NOT NULL,
+        exercise_name TEXT NOT NULL,
+        sets INTEGER NOT NULL DEFAULT 0,
+        visible_columns TEXT,
+        note TEXT,
+        done INTEGER NOT NULL DEFAULT 0
+      );
+
+      INSERT INTO Exercise_Instance_next (
+        exercise_instance_id,
+        workout_type_instance_id,
+        exercise_name,
+        sets,
+        visible_columns,
+        note,
+        done
+      )
+      SELECT
+        ${idColumn},
+        ${workoutColumn},
+        exercise_name,
+        COALESCE(sets, 0),
+        ${hasColumn(exerciseInstanceColumns, "visible_columns") ? "visible_columns" : "NULL"},
+        ${hasColumn(exerciseInstanceColumns, "note") ? "note" : "NULL"},
+        ${hasColumn(exerciseInstanceColumns, "done") ? "COALESCE(done, 0)" : "0"}
+      FROM Exercise_Instance;
+
+      DROP TABLE Exercise_Instance;
+      ALTER TABLE Exercise_Instance_next RENAME TO Exercise_Instance;
+    `);
 
     await db.execAsync("COMMIT;");
   } catch (error) {
@@ -234,7 +393,7 @@ async function repairStrengthTrainingState(db) {
       NOT EXISTS (
         SELECT 1
         FROM Sets
-        WHERE Sets.exercise_id = Exercise_Instance.exercise_id
+        WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
           AND Sets.done = 0
       )
     );
@@ -250,7 +409,7 @@ async function repairStrengthTrainingState(db) {
         ELSE NOT EXISTS (
           SELECT 1
           FROM Exercise_Instance
-          WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
+          WHERE Exercise_Instance.workout_type_instance_id = Workout_Type_Instance.workout_id
             AND Exercise_Instance.done = 0
         )
       END
@@ -258,7 +417,7 @@ async function repairStrengthTrainingState(db) {
     WHERE EXISTS (
       SELECT 1
       FROM Exercise_Instance
-      WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
+      WHERE Exercise_Instance.workout_type_instance_id = Workout_Type_Instance.workout_id
     );
   `);
 }
@@ -286,6 +445,8 @@ async function repairRunSetState(db) {
 export async function initializeDatabase(db) {
   await migrateWeightliftingTableNames(db);
   await migrateWorkoutTableName(db);
+  await migrateExerciseCatalogSchema(db);
+  await migrateExerciseInstanceSchema(db);
 
   await db.execAsync(`
     ${programSchemaSql}
@@ -335,12 +496,11 @@ export async function initializeDatabase(db) {
   await backfillWorkoutTypeInstances(db);
   await initializeWorkoutTypes(db);
 
-  await ensureTableColumns(db, "Exercise", [
-    ["primary_muscle_group_count", "INTEGER NOT NULL DEFAULT 0"],
-    ["secondary_muscle_group_count", "INTEGER NOT NULL DEFAULT 0"],
-  ]);
+  await ensureTableColumns(db, "Exercise", [["nickname", "TEXT"]]);
 
   await ensureTableColumns(db, "Exercise_Instance", [
+    ["exercise_name", "TEXT NOT NULL DEFAULT ''"],
+    ["sets", "INTEGER NOT NULL DEFAULT 0"],
     ["visible_columns", "TEXT"],
     ["note", "TEXT"],
     ["done", "INTEGER NOT NULL DEFAULT 0"],
@@ -375,7 +535,7 @@ export async function initializeDatabase(db) {
     SET sets = (
       SELECT COUNT(*)
       FROM Sets
-      WHERE Sets.exercise_id = Exercise_Instance.exercise_id
+      WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
     );
   `);
 

--- a/src/Database/schema/program.js
+++ b/src/Database/schema/program.js
@@ -45,9 +45,16 @@ export const programSchemaSql = `
       done INTEGER NOT NULL DEFAULT 0
   );
 
-  CREATE TABLE IF NOT EXISTS Workout (
+  CREATE TABLE IF NOT EXISTS Workout_Type (
+      workout_type_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      display_name TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS Workout_Type_Instance (
       workout_id INTEGER PRIMARY KEY AUTOINCREMENT,
       day_id INTEGER NOT NULL,
+      workout_type TEXT,
       date TEXT NOT NULL,
       label TEXT,
       done INTEGER NOT NULL DEFAULT 0,

--- a/src/Database/schema/program.js
+++ b/src/Database/schema/program.js
@@ -31,7 +31,6 @@ export const programSchemaSql = `
   CREATE TABLE IF NOT EXISTS Microcycle(
       microcycle_id INTEGER PRIMARY KEY AUTOINCREMENT,
       mesocycle_id INTEGER NOT NULL,
-      program_id INTEGER NOT NULL,
       microcycle_number INTEGER NOT NULL,
       focus TEXT DEFAULT "No focus",
       done INTEGER NOT NULL DEFAULT 0

--- a/src/Database/schema/program.js
+++ b/src/Database/schema/program.js
@@ -2,12 +2,20 @@ export const programSchemaSql = `
 
   CREATE TABLE IF NOT EXISTS Program (
     program_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cloud_program_id INTEGER,
     program_name TEXT,
     start_date TEXT NOT NULL,
     status TEXT
       DEFAULT 'NOT_STARTED'
       NOT NULL
-      CHECK (status IN ('COMPLETE', 'ACTIVE', 'NOT_STARTED'))
+      CHECK (status IN ('COMPLETE', 'ACTIVE', 'NOT_STARTED')),
+    needs_sync INTEGER NOT NULL DEFAULT 1
+  );
+
+  CREATE TABLE IF NOT EXISTS Program_Sync_Delete (
+    program_sync_delete_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cloud_program_id INTEGER NOT NULL UNIQUE,
+    deleted_at TEXT
   );
 
   CREATE TABLE IF NOT EXISTS Program_Best_Exercise (

--- a/src/Database/schema/weightlifting.js
+++ b/src/Database/schema/weightlifting.js
@@ -17,10 +17,10 @@ export const weightliftingSchemaSql = `
       done INTEGER NOT NULL DEFAULT 0
   );
 
-  CREATE TABLE IF NOT EXISTS Sets (
+  CREATE TABLE IF NOT EXISTS "Set" (
       sets_id INTEGER PRIMARY KEY AUTOINCREMENT,
       set_number INTEGER NOT NULL,
-      exercise_id INTEGER NOT NULL,
+      exercise_instance_id INTEGER NOT NULL,
       date TEXT,
 
       personal_record INTEGER NOT NULL DEFAULT 0,

--- a/src/Database/schema/weightlifting.js
+++ b/src/Database/schema/weightlifting.js
@@ -2,14 +2,15 @@ export const weightliftingSchemaSql = `
 
   CREATE TABLE IF NOT EXISTS Exercise (
       exercise_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      exercise_name TEXT NOT NULL
+      name TEXT NOT NULL UNIQUE,
+      nickname TEXT
   );
 
   CREATE TABLE IF NOT EXISTS Exercise_Instance (
-      exercise_id INTEGER PRIMARY KEY AUTOINCREMENT,
-      workout_id INTEGER NOT NULL,
+      exercise_instance_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workout_type_instance_id INTEGER NOT NULL,
       exercise_name TEXT NOT NULL,
-      sets INTEGER NOT NULL,
+      sets INTEGER NOT NULL DEFAULT 0,
       visible_columns TEXT,
       note TEXT,
 
@@ -19,7 +20,7 @@ export const weightliftingSchemaSql = `
   CREATE TABLE IF NOT EXISTS Sets (
       sets_id INTEGER PRIMARY KEY AUTOINCREMENT,
       set_number INTEGER NOT NULL,
-      exercise_id TEXT NOT NULL,
+      exercise_id INTEGER NOT NULL,
       date TEXT,
 
       personal_record INTEGER NOT NULL DEFAULT 0,
@@ -71,7 +72,7 @@ export async function initializeWeightliftingData(db) {
   if (checkExercisesInit.count === 0) {
     const placeholders = standardExercises.map(() => '(?)').join(', ');
     await db.runAsync(
-      `INSERT INTO Exercise (exercise_name) VALUES ${placeholders};`,
+      `INSERT INTO Exercise (name) VALUES ${placeholders};`,
       standardExercises
     );
   }

--- a/src/Pages/ExerciseLibraryPage/Components/ExerciseLibraryList/ExerciseLibraryList.js
+++ b/src/Pages/ExerciseLibraryPage/Components/ExerciseLibraryList/ExerciseLibraryList.js
@@ -51,7 +51,7 @@ const ExerciseLibraryList = ({ refreshKey }) => {
 
   const loadExerciseStorage = async () => {
     try {
-      const rows = await weightliftingRepository.getExerciseStorage(db);
+      const rows = await weightliftingRepository.getExerciseLibraryEntries(db);
       set_exercises(rows);
     } catch (error) {
       console.error("Error loading exercise storage", error);

--- a/src/Pages/MicrocyclePage/Components/MicrocycleList/MicrocycleList.js
+++ b/src/Pages/MicrocyclePage/Components/MicrocycleList/MicrocycleList.js
@@ -109,12 +109,13 @@ const MicrocycleList = ({
           workouts.every((workout) => workout.done === 1);
 
         const workoutCards = workouts.map((workout) => {
-          const found = getWorkoutIconConfig(workout.label);
+          const workoutType = workout.workout_type ?? workout.label;
+          const found = getWorkoutIconConfig(workoutType);
 
           return {
             key: workout.workout_id,
             icon: found?.Icon ?? null,
-            iconLabel: found?.short ?? workout.label,
+            iconLabel: found?.short ?? workout.label ?? workoutType,
             completed: workout.done === 1,
             workout,
           };
@@ -299,6 +300,7 @@ const MicrocycleList = ({
     navigation.navigate("WorkoutPage", {
       workout_id: workout.workout_id,
       workout_label: workout.label,
+      workout_type: workout.workout_type,
       day: day.day,
       date: day.date,
     });
@@ -330,6 +332,7 @@ const MicrocycleList = ({
       const workoutResult = await programRepository.createWorkoutForDay(db, {
         date: selectedDay.date,
         dayId: dayRow.day_id,
+        workoutType: labelId.id,
         label: labelId.id,
       });
 
@@ -343,6 +346,7 @@ const MicrocycleList = ({
         date: selectedDay.date,
         workout_id: workoutResult.lastInsertRowId,
         workout_label: labelId.id,
+        workout_type: labelId.id,
       });
     } catch (error) {
       console.error("Failed to create workout:", error);

--- a/src/Pages/ProgramOverviewPage/Components/TodayShortcut/TodayShortcut.js
+++ b/src/Pages/ProgramOverviewPage/Components/TodayShortcut/TodayShortcut.js
@@ -56,6 +56,9 @@ const TodayShortcut = ({ program_id }) => {
     return unsubscribe;
   }, [navigation, db, program_id, date]);
 
+  const getWorkoutType = (workout) =>
+    workout?.workout_type ?? workout?.label ?? null;
+
   const openWorkout = (workout) => {
     if (!workout) {
       return;
@@ -64,6 +67,7 @@ const TodayShortcut = ({ program_id }) => {
     navigation.navigate("WorkoutPage", {
       workout_id: workout.workout_id,
       workout_label: workout.label,
+      workout_type: getWorkoutType(workout),
       day: day?.Weekday,
       date,
       program_id,
@@ -179,7 +183,7 @@ const TodayShortcut = ({ program_id }) => {
         : "EXERCISES TODAY";
   const singleWorkout = workoutCount === 1 ? workouts[0] : null;
   const workoutIconConfig = singleWorkout
-    ? getWorkoutIconConfig(singleWorkout.label)
+    ? getWorkoutIconConfig(getWorkoutType(singleWorkout))
     : null;
   const HeroWorkoutIcon = workoutIconConfig?.Icon ?? null;
   const useCompactSingleWorkoutHeader =
@@ -411,7 +415,9 @@ const TodayShortcut = ({ program_id }) => {
               )}
 
               {visibleWorkoutPreviews.map((workout) => {
-                const workoutHeaderIconConfig = getWorkoutIconConfig(workout.label);
+                const workoutHeaderIconConfig = getWorkoutIconConfig(
+                  getWorkoutType(workout)
+                );
                 const WorkoutHeaderIcon = workoutHeaderIconConfig?.Icon ?? null;
 
                 return (

--- a/src/Pages/WeekPage/Components/Day/Day.js
+++ b/src/Pages/WeekPage/Components/Day/Day.js
@@ -58,7 +58,9 @@ const Day = ( {day, program_id, microcycle_id} ) => {
     const [pickMode, set_pickMode] = useState(null);
 
     //Helps show the correct icon.
-    const SelectedIcon = getWorkoutIconConfig(focusText)?.Icon;
+    const singleWorkoutType =
+        workouts.length === 1 ? (workouts[0]?.workout_type ?? workouts[0]?.label) : null;
+    const SelectedIcon = getWorkoutIconConfig(singleWorkoutType ?? focusText)?.Icon;
     
     //Visibility variabels for modals.
     const [pickWorkoutModal_visible, set_pickWorkoutModal_visible] = useState(false);
@@ -160,7 +162,9 @@ const Day = ( {day, program_id, microcycle_id} ) => {
                             workout_id: workouts[0].workout_id,
                             day: day,
                             date: date,
-                            workout_label: workouts[0].label,})   
+                            workout_label: workouts[0].label,
+                            workout_type: workouts[0].workout_type,
+                        })
                     } else if (workouts.length > 1){
 
                         set_pickMode(PICK_MODE.NAVIGATE);
@@ -358,6 +362,7 @@ const Day = ( {day, program_id, microcycle_id} ) => {
                 const workout_id = await programRepository.createWorkoutForDay(db, {
                     date,
                     dayId: day_id,
+                    workoutType: labelId.id,
                     label: labelId.id,
                 });
 
@@ -366,6 +371,7 @@ const Day = ( {day, program_id, microcycle_id} ) => {
                     date,
                     workout_id: workout_id.lastInsertRowId,
                     workout_label: labelId.id,
+                    workout_type: labelId.id,
                 });
             }}
         />
@@ -382,6 +388,8 @@ const Day = ( {day, program_id, microcycle_id} ) => {
                         program_id: program_id,
                         date: date,
                         workout_id: workout.workout_id,
+                        workout_label: workout.label,
+                        workout_type: workout.workout_type,
                     });
                 }
 

--- a/src/Pages/WorkoutPage/WorkoutPage.js
+++ b/src/Pages/WorkoutPage/WorkoutPage.js
@@ -31,6 +31,7 @@ const WorkoutPage = ({ route }) => {
   const {
     workout_id,
     workout_label: initialWorkoutLabel,
+    workout_type: initialWorkoutType,
     day: initialDay,
     date: initialDate,
     program_id: initialProgramId,
@@ -64,18 +65,21 @@ const WorkoutPage = ({ route }) => {
     };
   }, [db, workout_id]);
 
-  const workoutLabel = metadata?.workout_label ?? initialWorkoutLabel ?? "Workout";
+  const workoutType =
+    metadata?.workout_type ?? initialWorkoutType ?? initialWorkoutLabel ?? null;
+  const workoutLabel =
+    metadata?.workout_label ?? initialWorkoutLabel ?? workoutType ?? "Workout";
   const workoutDay = metadata?.day ?? initialDay ?? "";
   const workoutDate = metadata?.date ?? initialDate ?? "";
   const programId = metadata?.program_id ?? initialProgramId;
   const workoutSubtitle = [workoutDay, workoutDate].filter(Boolean).join(" - ");
   const headerEyebrowColor = theme.quietText ?? theme.iconColor;
-  const isRunWorkout = workoutLabel === "Run";
+  const isRunWorkout = workoutType === "Run";
   const isStrengthWorkout =
-    workoutLabel === "Resistance" ||
-    workoutLabel === "Upperbody" ||
-    workoutLabel === "Legs" ||
-    workoutLabel === "StrengthTraining";
+    workoutType === "Resistance" ||
+    workoutType === "Upperbody" ||
+    workoutType === "Legs" ||
+    workoutType === "StrengthTraining";
   const supportsTimerRestart = isRunWorkout || isStrengthWorkout;
 
   const deleteWorkout = async () => {

--- a/src/Repository/programRepository.js
+++ b/src/Repository/programRepository.js
@@ -28,10 +28,11 @@ export async function getProgramsOverview(db) {
        ON mesocycles.program_id = p.program_id
      LEFT JOIN (
         SELECT
-          program_id,
+          m.program_id,
           COUNT(*) AS week_count
-        FROM Microcycle
-        GROUP BY program_id
+        FROM Microcycle mc
+        JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
+        GROUP BY m.program_id
      ) microcycles
        ON microcycles.program_id = p.program_id
      LEFT JOIN (
@@ -330,8 +331,9 @@ export async function countMesocyclesByProgram(db, programId) {
 export async function countMicrocyclesByProgram(db, programId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Microcycle
-     WHERE program_id = ?;`,
+     FROM Microcycle mc
+     JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
+     WHERE m.program_id = ?;`,
     [programId]
   );
 }
@@ -349,12 +351,12 @@ export async function insertMesocycle(
 
 export async function insertMicrocycle(
   db,
-  { mesocycleId, programId, microcycleNumber }
+  { mesocycleId, microcycleNumber }
 ) {
   return db.runAsync(
-    `INSERT INTO Microcycle (mesocycle_id, program_id, microcycle_number)
-     VALUES (?, ?, ?);`,
-    [mesocycleId, programId, microcycleNumber]
+    `INSERT INTO Microcycle (mesocycle_id, microcycle_number)
+     VALUES (?, ?);`,
+    [mesocycleId, microcycleNumber]
   );
 }
 
@@ -402,9 +404,15 @@ export async function updateMesocycleFocus(db, { mesocycleId, focus }) {
 
 export async function getMicrocyclesByMesocycle(db, mesocycleId) {
   return db.getAllAsync(
-    `SELECT microcycle_id, microcycle_number, program_id, focus, done
-     FROM Microcycle
-     WHERE mesocycle_id = ?;`,
+    `SELECT
+        mc.microcycle_id,
+        mc.microcycle_number,
+        m.program_id,
+        mc.focus,
+        mc.done
+     FROM Microcycle mc
+     JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
+     WHERE mc.mesocycle_id = ?;`,
     [mesocycleId]
   );
 }
@@ -555,7 +563,7 @@ export async function getMicrocycleNumberAndMesocycleNumber(
      FROM Microcycle mc
      JOIN Mesocycle m ON mc.mesocycle_id = m.mesocycle_id
      WHERE mc.microcycle_id = ?
-       AND mc.program_id = ?;`,
+       AND m.program_id = ?;`,
     [microcycleId, programId]
   );
 }
@@ -614,10 +622,14 @@ export async function getWorkoutLabelsByDay(db, dayId) {
 
 export async function getAllMicrocyclesByProgram(db, programId) {
   return db.getAllAsync(
-    `SELECT microcycle_id, microcycle_number, mesocycle_id
-     FROM Microcycle
-     WHERE program_id = ?
-     ORDER BY microcycle_number;`,
+    `SELECT
+        mc.microcycle_id,
+        mc.microcycle_number,
+        mc.mesocycle_id
+     FROM Microcycle mc
+     JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
+     WHERE m.program_id = ?
+     ORDER BY mc.microcycle_number;`,
     [programId]
   );
 }

--- a/src/Repository/programRepository.js
+++ b/src/Repository/programRepository.js
@@ -184,8 +184,8 @@ export async function getSetDoneStatesByDayId(db, dayId) {
   return db.getAllAsync(
     `SELECT s.done
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      WHERE w.day_id = ?;`,
     [dayId]
   );
@@ -199,8 +199,8 @@ export async function getCompletedStrengthSetsByProgram(db, programId) {
         s.reps,
         COALESCE(s.date, d.date) AS performed_date
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
        AND s.done = 1
@@ -215,9 +215,9 @@ export async function deleteSetsByProgram(db, programId) {
   await db.runAsync(
     `DELETE FROM Sets
      WHERE exercise_id IN (
-       SELECT e.exercise_id
+       SELECT e.exercise_instance_id
        FROM Exercise_Instance e
-       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -230,7 +230,7 @@ export async function deleteSetsByProgram(db, programId) {
 export async function deleteExercisesByProgram(db, programId) {
   await db.runAsync(
     `DELETE FROM Exercise_Instance
-     WHERE workout_id IN (
+     WHERE workout_type_instance_id IN (
        SELECT w.workout_id
        FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
@@ -458,9 +458,9 @@ export async function deleteSetsByMesocycle(db, mesocycleId) {
   await db.runAsync(
     `DELETE FROM Sets
      WHERE exercise_id IN (
-       SELECT e.exercise_id
+       SELECT e.exercise_instance_id
        FROM Exercise_Instance e
-       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        WHERE mc.mesocycle_id = ?
@@ -472,7 +472,7 @@ export async function deleteSetsByMesocycle(db, mesocycleId) {
 export async function deleteExercisesByMesocycle(db, mesocycleId) {
   await db.runAsync(
     `DELETE FROM Exercise_Instance
-     WHERE workout_id IN (
+     WHERE workout_type_instance_id IN (
        SELECT w.workout_id
        FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
@@ -675,9 +675,9 @@ export async function deleteSetsByMicrocycle(db, microcycleId) {
   await db.runAsync(
     `DELETE FROM Sets
      WHERE exercise_id IN (
-       SELECT e.exercise_id
+       SELECT e.exercise_instance_id
        FROM Exercise_Instance e
-       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
        JOIN Day d ON d.day_id = w.day_id
        WHERE d.microcycle_id = ?
      );`,
@@ -688,7 +688,7 @@ export async function deleteSetsByMicrocycle(db, microcycleId) {
 export async function deleteExercisesByMicrocycle(db, microcycleId) {
   await db.runAsync(
     `DELETE FROM Exercise_Instance
-     WHERE workout_id IN (
+     WHERE workout_type_instance_id IN (
        SELECT w.workout_id
        FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id

--- a/src/Repository/programRepository.js
+++ b/src/Repository/programRepository.js
@@ -6,6 +6,100 @@ export async function createProgram(db, { programName, startDate, status }) {
   );
 }
 
+export async function getProgramsForCloudSync(db) {
+  return db.getAllAsync(
+    `SELECT
+        program_id,
+        cloud_program_id,
+        program_name,
+        start_date,
+        status,
+        needs_sync
+     FROM Program
+     ORDER BY program_id ASC;`
+  );
+}
+
+export async function createProgramFromCloud(
+  db,
+  { cloudProgramId, programName, startDate, status }
+) {
+  return db.runAsync(
+    `INSERT INTO Program (
+      cloud_program_id,
+      program_name,
+      start_date,
+      status,
+      needs_sync
+    ) VALUES (?, ?, ?, ?, 0);`,
+    [cloudProgramId, programName, startDate, status]
+  );
+}
+
+export async function updateProgramFromCloud(
+  db,
+  { programId, cloudProgramId, programName, startDate, status }
+) {
+  await db.runAsync(
+    `UPDATE Program
+     SET cloud_program_id = ?,
+         program_name = ?,
+         start_date = ?,
+         status = ?,
+         needs_sync = 0
+     WHERE program_id = ?;`,
+    [cloudProgramId, programName, startDate, status, programId]
+  );
+}
+
+export async function markProgramSynced(db, { programId, cloudProgramId }) {
+  await db.runAsync(
+    `UPDATE Program
+     SET cloud_program_id = ?,
+         needs_sync = 0
+     WHERE program_id = ?;`,
+    [cloudProgramId, programId]
+  );
+}
+
+export async function getProgramSyncMetadata(db, programId) {
+  return db.getFirstAsync(
+    `SELECT program_id, cloud_program_id, needs_sync
+     FROM Program
+     WHERE program_id = ?;`,
+    [programId]
+  );
+}
+
+export async function getQueuedProgramDeletes(db) {
+  return db.getAllAsync(
+    `SELECT
+        program_sync_delete_id,
+        cloud_program_id,
+        deleted_at
+     FROM Program_Sync_Delete
+     ORDER BY program_sync_delete_id ASC;`
+  );
+}
+
+export async function queueProgramDeleteSync(db, { cloudProgramId, deletedAt }) {
+  await db.runAsync(
+    `INSERT OR IGNORE INTO Program_Sync_Delete (
+      cloud_program_id,
+      deleted_at
+    ) VALUES (?, ?);`,
+    [cloudProgramId, deletedAt]
+  );
+}
+
+export async function deleteQueuedProgramDelete(db, queueId) {
+  await db.runAsync(
+    `DELETE FROM Program_Sync_Delete
+     WHERE program_sync_delete_id = ?;`,
+    [queueId]
+  );
+}
+
 export async function getProgramsOverview(db) {
   return db.getAllAsync(
     `SELECT
@@ -117,7 +211,8 @@ export async function upsertProgramBestExerciseSelection(
 export async function updateProgramStatus(db, { programId, status }) {
   await db.runAsync(
     `UPDATE Program
-     SET status = ?
+     SET status = ?,
+         needs_sync = 1
      WHERE program_id = ?;`,
     [status, programId]
   );
@@ -126,7 +221,8 @@ export async function updateProgramStatus(db, { programId, status }) {
 export async function updateProgramName(db, { programId, programName }) {
   await db.runAsync(
     `UPDATE Program
-     SET program_name = ?
+     SET program_name = ?,
+         needs_sync = 1
      WHERE program_id = ?;`,
     [programName, programId]
   );

--- a/src/Repository/programRepository.js
+++ b/src/Repository/programRepository.js
@@ -183,8 +183,8 @@ export async function getWorkoutOptions(db, programId) {
 export async function getSetDoneStatesByDayId(db, dayId) {
   return db.getAllAsync(
     `SELECT s.done
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      WHERE w.day_id = ?;`,
     [dayId]
@@ -198,8 +198,8 @@ export async function getCompletedStrengthSetsByProgram(db, programId) {
         s.weight,
         s.reps,
         COALESCE(s.date, d.date) AS performed_date
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
@@ -213,8 +213,8 @@ export async function getCompletedStrengthSetsByProgram(db, programId) {
 
 export async function deleteSetsByProgram(db, programId) {
   await db.runAsync(
-    `DELETE FROM Sets
-     WHERE exercise_id IN (
+    `DELETE FROM "Set"
+     WHERE exercise_instance_id IN (
        SELECT e.exercise_instance_id
        FROM Exercise_Instance e
        JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
@@ -456,8 +456,8 @@ export async function incrementMesocycleWeeks(db, mesocycleId) {
 
 export async function deleteSetsByMesocycle(db, mesocycleId) {
   await db.runAsync(
-    `DELETE FROM Sets
-     WHERE exercise_id IN (
+    `DELETE FROM "Set"
+     WHERE exercise_instance_id IN (
        SELECT e.exercise_instance_id
        FROM Exercise_Instance e
        JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
@@ -673,8 +673,8 @@ export async function getWorkoutsByDay(db, dayId) {
 
 export async function deleteSetsByMicrocycle(db, microcycleId) {
   await db.runAsync(
-    `DELETE FROM Sets
-     WHERE exercise_id IN (
+    `DELETE FROM "Set"
+     WHERE exercise_instance_id IN (
        SELECT e.exercise_instance_id
        FROM Exercise_Instance e
        JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id

--- a/src/Repository/programRepository.js
+++ b/src/Repository/programRepository.js
@@ -48,7 +48,7 @@ export async function getProgramsOverview(db) {
           d.program_id,
           COUNT(w.workout_id) AS workout_count
         FROM Day d
-        LEFT JOIN Workout w
+        LEFT JOIN Workout_Type_Instance w
           ON w.day_id = d.day_id
         GROUP BY d.program_id
      ) workouts
@@ -153,8 +153,13 @@ export async function getDayByProgramAndDate(db, { programId, date }) {
 
 export async function getWorkoutsByDayId(db, dayId) {
   return db.getAllAsync(
-    `SELECT workout_id, label, done, day_id
-     FROM Workout
+    `SELECT
+        workout_id,
+        workout_type,
+        COALESCE(label, workout_type) AS label,
+        done,
+        day_id
+     FROM Workout_Type_Instance
      WHERE day_id = ?;`,
     [dayId]
   );
@@ -162,8 +167,12 @@ export async function getWorkoutsByDayId(db, dayId) {
 
 export async function getWorkoutOptions(db, programId) {
   return db.getAllAsync(
-    `SELECT w.workout_id, w.date
-     FROM Workout w
+    `SELECT
+        w.workout_id,
+        w.workout_type,
+        COALESCE(w.label, w.workout_type) AS label,
+        w.date
+     FROM Workout_Type_Instance w
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
      ORDER BY w.date;`,
@@ -176,7 +185,7 @@ export async function getSetDoneStatesByDayId(db, dayId) {
     `SELECT s.done
      FROM Sets s
      JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout w ON w.workout_id = e.workout_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
      WHERE w.day_id = ?;`,
     [dayId]
   );
@@ -191,7 +200,7 @@ export async function getCompletedStrengthSetsByProgram(db, programId) {
         COALESCE(s.date, d.date) AS performed_date
      FROM Sets s
      JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout w ON w.workout_id = e.workout_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
        AND s.done = 1
@@ -208,7 +217,7 @@ export async function deleteSetsByProgram(db, programId) {
      WHERE exercise_id IN (
        SELECT e.exercise_id
        FROM Exercise_Instance e
-       JOIN Workout w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -223,7 +232,7 @@ export async function deleteExercisesByProgram(db, programId) {
     `DELETE FROM Exercise_Instance
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -238,7 +247,7 @@ export async function deleteRunsByProgram(db, programId) {
     `DELETE FROM Run
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -250,7 +259,7 @@ export async function deleteRunsByProgram(db, programId) {
 
 export async function deleteWorkoutsByProgram(db, programId) {
   await db.runAsync(
-    `DELETE FROM Workout
+    `DELETE FROM Workout_Type_Instance
      WHERE day_id IN (
        SELECT d.day_id
        FROM Day d
@@ -386,7 +395,7 @@ export async function getMesocycleWorkoutCountsByProgram(db, programId) {
      FROM Mesocycle m
      LEFT JOIN Microcycle mc ON mc.mesocycle_id = m.mesocycle_id
      LEFT JOIN Day d ON d.microcycle_id = mc.microcycle_id
-     LEFT JOIN Workout w ON w.day_id = d.day_id
+     LEFT JOIN Workout_Type_Instance w ON w.day_id = d.day_id
      WHERE m.program_id = ?
      GROUP BY m.mesocycle_id;`,
     [programId]
@@ -451,7 +460,7 @@ export async function deleteSetsByMesocycle(db, mesocycleId) {
      WHERE exercise_id IN (
        SELECT e.exercise_id
        FROM Exercise_Instance e
-       JOIN Workout w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        WHERE mc.mesocycle_id = ?
@@ -465,7 +474,7 @@ export async function deleteExercisesByMesocycle(db, mesocycleId) {
     `DELETE FROM Exercise_Instance
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        WHERE mc.mesocycle_id = ?
@@ -479,7 +488,7 @@ export async function deleteRunsByMesocycle(db, mesocycleId) {
     `DELETE FROM Run
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
        WHERE mc.mesocycle_id = ?
@@ -490,7 +499,7 @@ export async function deleteRunsByMesocycle(db, mesocycleId) {
 
 export async function deleteWorkoutsByMesocycle(db, mesocycleId) {
   await db.runAsync(
-    `DELETE FROM Workout
+    `DELETE FROM Workout_Type_Instance
      WHERE day_id IN (
        SELECT d.day_id
        FROM Day d
@@ -580,7 +589,7 @@ export async function updateMicrocycleFocus(db, { microcycleId, focus }) {
 export async function getTotalWorkoutCountByMicrocycle(db, microcycleId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Workout w
+     FROM Workout_Type_Instance w
      JOIN Day d ON w.day_id = d.day_id
      WHERE d.microcycle_id = ?;`,
     [microcycleId]
@@ -590,7 +599,7 @@ export async function getTotalWorkoutCountByMicrocycle(db, microcycleId) {
 export async function getDoneWorkoutCountByMicrocycle(db, microcycleId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Workout w
+     FROM Workout_Type_Instance w
      JOIN Day d ON w.day_id = d.day_id
      WHERE d.microcycle_id = ?
        AND w.done = 1;`,
@@ -613,8 +622,8 @@ export async function getDayByMicrocycleAndDate(
 
 export async function getWorkoutLabelsByDay(db, dayId) {
   return db.getAllAsync(
-    `SELECT label
-     FROM Workout
+    `SELECT COALESCE(label, workout_type) AS label
+     FROM Workout_Type_Instance
      WHERE day_id = ?;`,
     [dayId]
   );
@@ -645,8 +654,18 @@ export async function getDaysByMicrocycle(db, microcycleId) {
 
 export async function getWorkoutsByDay(db, dayId) {
   return db.getAllAsync(
-    `SELECT *
-     FROM Workout
+    `SELECT
+        workout_id,
+        day_id,
+        workout_type,
+        date,
+        COALESCE(label, workout_type) AS label,
+        done,
+        is_active,
+        original_start_time,
+        timer_start,
+        elapsed_time
+     FROM Workout_Type_Instance
      WHERE day_id = ?;`,
     [dayId]
   );
@@ -658,7 +677,7 @@ export async function deleteSetsByMicrocycle(db, microcycleId) {
      WHERE exercise_id IN (
        SELECT e.exercise_id
        FROM Exercise_Instance e
-       JOIN Workout w ON w.workout_id = e.workout_id
+       JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
        JOIN Day d ON d.day_id = w.day_id
        WHERE d.microcycle_id = ?
      );`,
@@ -671,7 +690,7 @@ export async function deleteExercisesByMicrocycle(db, microcycleId) {
     `DELETE FROM Exercise_Instance
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        WHERE d.microcycle_id = ?
      );`,
@@ -684,7 +703,7 @@ export async function deleteRunsByMicrocycle(db, microcycleId) {
     `DELETE FROM Run
      WHERE workout_id IN (
        SELECT w.workout_id
-       FROM Workout w
+       FROM Workout_Type_Instance w
        JOIN Day d ON d.day_id = w.day_id
        WHERE d.microcycle_id = ?
      );`,
@@ -694,7 +713,7 @@ export async function deleteRunsByMicrocycle(db, microcycleId) {
 
 export async function deleteWorkoutsByMicrocycle(db, microcycleId) {
   await db.runAsync(
-    `DELETE FROM Workout
+    `DELETE FROM Workout_Type_Instance
      WHERE day_id IN (
        SELECT day_id
        FROM Day
@@ -733,11 +752,14 @@ export async function getDayByWeekdayAndMicrocycle(
   );
 }
 
-export async function createWorkout(db, { date, dayId, label }) {
+export async function createWorkout(
+  db,
+  { date, dayId, workoutType = null, label = workoutType }
+) {
   return db.runAsync(
-    `INSERT INTO Workout (date, day_id, label)
-     VALUES (?, ?, ?);`,
-    [date, dayId, label]
+    `INSERT INTO Workout_Type_Instance (date, day_id, workout_type, label)
+     VALUES (?, ?, ?, ?);`,
+    [date, dayId, workoutType ?? label, label ?? workoutType]
   );
 }
 
@@ -746,9 +768,13 @@ export async function copyWorkoutIntoDay(
   { date, dayId, workoutId }
 ) {
   return db.runAsync(
-    `INSERT INTO Workout (date, day_id, label)
-     SELECT ?, ?, label
-     FROM Workout
+    `INSERT INTO Workout_Type_Instance (date, day_id, workout_type, label)
+     SELECT
+       ?,
+       ?,
+       COALESCE(workout_type, label),
+       COALESCE(label, workout_type)
+     FROM Workout_Type_Instance
      WHERE workout_id = ?;`,
     [date, dayId, workoutId]
   );
@@ -766,7 +792,7 @@ export async function getDayByDate(db, { programId, date }) {
 
 export async function deleteWorkoutById(db, workoutId) {
   await db.runAsync(
-    `DELETE FROM Workout
+    `DELETE FROM Workout_Type_Instance
      WHERE workout_id = ?;`,
     [workoutId]
   );

--- a/src/Repository/weightliftingRepository.js
+++ b/src/Repository/weightliftingRepository.js
@@ -265,8 +265,8 @@ export async function getEstimatedWeightBySetId(db, setId) {
             ELSE 0
           END
         ) AS adjusted_estimated_weight
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      JOIN Day d ON d.day_id = w.day_id
      JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
@@ -285,8 +285,8 @@ export async function getEstimatedWeightBySetId(db, setId) {
 export async function getTotalPlannedSetsByWorkout(db, workoutId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      WHERE e.workout_type_instance_id = ?;`,
     [workoutId]
   );
@@ -295,8 +295,8 @@ export async function getTotalPlannedSetsByWorkout(db, workoutId) {
 export async function getDoneSetCountByWorkout(db, workoutId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS done_sets
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      WHERE e.workout_type_instance_id = ?
        AND s.done = 1;`,
     [workoutId]
@@ -343,8 +343,8 @@ export async function getExerciseSummariesByWorkout(db, workoutId) {
 export async function getSetsByWorkout(db, workoutId) {
   return db.getAllAsync(
     `SELECT s.*
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      WHERE e.workout_type_instance_id = ?;`,
     [workoutId]
   );
@@ -401,8 +401,8 @@ export async function getWorkoutIdByExercise(db, exerciseId) {
 
 export async function deleteSetsByExercise(db, exerciseId) {
   await db.runAsync(
-    `DELETE FROM Sets
-     WHERE exercise_id = ?;`,
+    `DELETE FROM "Set"
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -418,8 +418,8 @@ export async function deleteExerciseById(db, exerciseId) {
 export async function countSetsByExercise(db, exerciseId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Sets
-     WHERE exercise_id = ?;`,
+     FROM "Set"
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -443,9 +443,9 @@ export async function createSet(
   }
 ) {
   return db.runAsync(
-    `INSERT INTO Sets (
+    `INSERT INTO "Set" (
       set_number,
-      exercise_id,
+      exercise_instance_id,
       date,
       personal_record,
       pause,
@@ -481,8 +481,8 @@ export async function updateExerciseSetCount(db, exerciseId) {
     `UPDATE Exercise_Instance
      SET sets = (
        SELECT COUNT(*)
-       FROM Sets
-       WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
+       FROM "Set"
+       WHERE "Set".exercise_instance_id = Exercise_Instance.exercise_instance_id
      )
      WHERE exercise_instance_id = ?;`,
     [exerciseId]
@@ -495,9 +495,9 @@ export async function updateExerciseDoneFromSets(db, exerciseId) {
      SET done = (
        NOT EXISTS (
          SELECT 1
-         FROM Sets
-         WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
-           AND Sets.done = 0
+         FROM "Set"
+         WHERE "Set".exercise_instance_id = Exercise_Instance.exercise_instance_id
+           AND "Set".done = 0
        )
      )
      WHERE exercise_instance_id = ?;`,
@@ -528,7 +528,7 @@ export async function updateExerciseNote(db, { exerciseId, note }) {
 
 export async function updateSetDone(db, { setId, done }) {
   await db.runAsync(
-    `UPDATE Sets
+    `UPDATE "Set"
      SET done = ?
      WHERE sets_id = ?;`,
     [done ? 1 : 0, setId]
@@ -541,14 +541,14 @@ export async function updateExerciseDoneBySet(db, setId) {
      SET done = (
        NOT EXISTS (
          SELECT 1
-         FROM Sets
-         WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
-           AND Sets.done = 0
+         FROM "Set"
+         WHERE "Set".exercise_instance_id = Exercise_Instance.exercise_instance_id
+           AND "Set".done = 0
        )
      )
      WHERE exercise_instance_id = (
-       SELECT exercise_id
-       FROM Sets
+       SELECT exercise_instance_id
+       FROM "Set"
        WHERE sets_id = ?
      );`,
     [setId]
@@ -573,9 +573,9 @@ export async function updateWorkoutDoneFromExercises(db, workoutId) {
 
 export async function getExerciseAndWorkoutBySetId(db, setId) {
   return db.getFirstAsync(
-    `SELECT s.exercise_id, e.workout_type_instance_id AS workout_id
-     FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+    `SELECT s.exercise_instance_id, e.workout_type_instance_id AS workout_id
+     FROM "Set" s
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_instance_id
      WHERE s.sets_id = ?;`,
     [setId]
   );
@@ -583,7 +583,7 @@ export async function getExerciseAndWorkoutBySetId(db, setId) {
 
 export async function deleteSetById(db, setId) {
   await db.runAsync(
-    `DELETE FROM Sets
+    `DELETE FROM "Set"
      WHERE sets_id = ?;`,
     [setId]
   );
@@ -592,8 +592,8 @@ export async function deleteSetById(db, setId) {
 export async function getSetIdsByExercise(db, exerciseId) {
   return db.getAllAsync(
     `SELECT sets_id
-     FROM Sets
-     WHERE exercise_id = ?
+     FROM "Set"
+     WHERE exercise_instance_id = ?
      ORDER BY set_number ASC, sets_id ASC;`,
     [exerciseId]
   );
@@ -601,7 +601,7 @@ export async function getSetIdsByExercise(db, exerciseId) {
 
 export async function updateSetNumber(db, { setId, setNumber }) {
   await db.runAsync(
-    `UPDATE Sets
+    `UPDATE "Set"
      SET set_number = ?
      WHERE sets_id = ?;`,
     [setNumber, setId]
@@ -610,7 +610,7 @@ export async function updateSetNumber(db, { setId, setNumber }) {
 
 export async function updateSetField(db, { field, value, setId }) {
   await db.runAsync(
-    `UPDATE Sets
+    `UPDATE "Set"
      SET ${field} = ?
      WHERE sets_id = ?;`,
     [value, setId]
@@ -619,9 +619,9 @@ export async function updateSetField(db, { field, value, setId }) {
 
 export async function getExerciseSets(db, exerciseId) {
   return db.getAllAsync(
-    `SELECT set_number, pause, rpe, weight, rm_percentage, reps, done, failed, amrap, note
-     FROM Sets
-     WHERE exercise_id = ?;`,
+    `SELECT set_number, exercise_instance_id, pause, rpe, weight, rm_percentage, reps, done, failed, amrap, note
+     FROM "Set"
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -629,8 +629,8 @@ export async function getExerciseSets(db, exerciseId) {
 export async function getExerciseSetCount(db, exerciseId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
-     FROM Sets
-     WHERE exercise_id = ?;`,
+     FROM "Set"
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -652,7 +652,7 @@ export async function updateSetByExerciseAndNumber(
   }
 ) {
   await db.runAsync(
-    `UPDATE Sets
+    `UPDATE "Set"
      SET pause = ?,
          rpe = ?,
          weight = ?,
@@ -662,7 +662,7 @@ export async function updateSetByExerciseAndNumber(
          failed = ?,
          amrap = ?,
          note = ?
-     WHERE exercise_id = ?
+     WHERE exercise_instance_id = ?
        AND set_number = ?;`,
     [
       pause,
@@ -691,8 +691,8 @@ export async function updateExerciseDone(db, { exerciseId, done }) {
 
 export async function deleteSetsByWorkout(db, workoutId) {
   await db.runAsync(
-    `DELETE FROM Sets
-     WHERE exercise_id IN (
+    `DELETE FROM "Set"
+     WHERE exercise_instance_id IN (
        SELECT exercise_instance_id
        FROM Exercise_Instance
        WHERE workout_type_instance_id = ?
@@ -712,8 +712,8 @@ export async function deleteExercisesByWorkout(db, workoutId) {
 export async function getSetsByExercise(db, exerciseId) {
   return db.getAllAsync(
     `SELECT *
-     FROM Sets
-     WHERE exercise_id = ?;`,
+     FROM "Set"
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }

--- a/src/Repository/weightliftingRepository.js
+++ b/src/Repository/weightliftingRepository.js
@@ -270,7 +270,7 @@ export async function getEstimatedWeightBySetId(db, setId) {
         ) AS adjusted_estimated_weight
      FROM Sets s
      JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout w ON w.workout_id = e.workout_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
      JOIN Day d ON d.day_id = w.day_id
      JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
      JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -325,7 +325,7 @@ export async function getProgramExerciseNames(db, programId) {
   return db.getAllAsync(
     `SELECT DISTINCT e.exercise_name
      FROM Exercise_Instance e
-     JOIN Workout w ON w.workout_id = e.workout_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
      ORDER BY e.exercise_name COLLATE NOCASE ASC;`,
@@ -552,12 +552,12 @@ export async function updateExerciseDoneBySet(db, setId) {
 
 export async function updateWorkoutDoneFromExercises(db, workoutId) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET done = (
        NOT EXISTS (
          SELECT 1
          FROM Exercise_Instance
-         WHERE Exercise_Instance.workout_id = Workout.workout_id
+         WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
            AND Exercise_Instance.done = 0
        )
      )

--- a/src/Repository/weightliftingRepository.js
+++ b/src/Repository/weightliftingRepository.js
@@ -1,18 +1,17 @@
 export async function getExerciseStorage(db) {
   return db.getAllAsync(
     `SELECT
-        exercise_name,
-        COALESCE(primary_muscle_group_count, 0) AS primary_muscle_group_count,
-        COALESCE(secondary_muscle_group_count, 0) AS secondary_muscle_group_count
+        name AS exercise_name,
+        nickname
      FROM Exercise
-     ORDER BY exercise_name COLLATE NOCASE ASC;`
+     ORDER BY name COLLATE NOCASE ASC;`
   );
 }
 
 export async function createExerciseStorage(db, exerciseName) {
   await db.runAsync(
-    `INSERT INTO Exercise (exercise_name)
-     VALUES (?);`,
+    `INSERT INTO Exercise (name, nickname)
+     VALUES (?, NULL);`,
     [exerciseName]
   );
 }
@@ -24,18 +23,16 @@ export async function replaceExerciseCatalog(db, exercises) {
     await db.runAsync(`DELETE FROM Exercise;`);
 
     if (exercises.length > 0) {
-      const placeholders = exercises.map(() => "(?, ?, ?)").join(", ");
+      const placeholders = exercises.map(() => "(?, ?)").join(", ");
       const values = exercises.flatMap((exercise) => [
-        exercise.exercise_name,
-        exercise.primary_muscle_group_count ?? 0,
-        exercise.secondary_muscle_group_count ?? 0,
+        exercise.name ?? exercise.exercise_name,
+        exercise.nickname ?? null,
       ]);
 
       await db.runAsync(
         `INSERT INTO Exercise (
-          exercise_name,
-          primary_muscle_group_count,
-          secondary_muscle_group_count
+          name,
+          nickname
         ) VALUES ${placeholders};`,
         values
       );
@@ -269,8 +266,8 @@ export async function getEstimatedWeightBySetId(db, setId) {
           END
         ) AS adjusted_estimated_weight
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      JOIN Day d ON d.day_id = w.day_id
      JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
      JOIN Mesocycle m ON m.mesocycle_id = mc.mesocycle_id
@@ -289,8 +286,8 @@ export async function getTotalPlannedSetsByWorkout(db, workoutId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS count
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     WHERE e.workout_id = ?;`,
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     WHERE e.workout_type_instance_id = ?;`,
     [workoutId]
   );
 }
@@ -299,8 +296,8 @@ export async function getDoneSetCountByWorkout(db, workoutId) {
   return db.getFirstAsync(
     `SELECT COUNT(*) AS done_sets
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     WHERE e.workout_id = ?
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     WHERE e.workout_type_instance_id = ?
        AND s.done = 1;`,
     [workoutId]
   );
@@ -309,14 +306,15 @@ export async function getDoneSetCountByWorkout(db, workoutId) {
 export async function getExercisesByWorkout(db, workoutId) {
   return db.getAllAsync(
     `SELECT
-        exercise_id,
+        exercise_instance_id AS exercise_id,
+        workout_type_instance_id AS workout_id,
         exercise_name,
         sets,
         done,
         visible_columns,
         note
      FROM Exercise_Instance
-     WHERE workout_id = ?;`,
+     WHERE workout_type_instance_id = ?;`,
     [workoutId]
   );
 }
@@ -325,7 +323,7 @@ export async function getProgramExerciseNames(db, programId) {
   return db.getAllAsync(
     `SELECT DISTINCT e.exercise_name
      FROM Exercise_Instance e
-     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_id
+     JOIN Workout_Type_Instance w ON w.workout_id = e.workout_type_instance_id
      JOIN Day d ON d.day_id = w.day_id
      WHERE d.program_id = ?
      ORDER BY e.exercise_name COLLATE NOCASE ASC;`,
@@ -337,7 +335,7 @@ export async function getExerciseSummariesByWorkout(db, workoutId) {
   return db.getAllAsync(
     `SELECT exercise_name, sets
      FROM Exercise_Instance
-     WHERE workout_id = ?;`,
+     WHERE workout_type_instance_id = ?;`,
     [workoutId]
   );
 }
@@ -346,17 +344,24 @@ export async function getSetsByWorkout(db, workoutId) {
   return db.getAllAsync(
     `SELECT s.*
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
-     WHERE e.workout_id = ?;`,
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
+     WHERE e.workout_type_instance_id = ?;`,
     [workoutId]
   );
 }
 
 export async function getExercisesByWorkoutId(db, workoutId) {
   return db.getAllAsync(
-    `SELECT *
+    `SELECT
+        exercise_instance_id AS exercise_id,
+        workout_type_instance_id AS workout_id,
+        exercise_name,
+        sets,
+        visible_columns,
+        note,
+        done
      FROM Exercise_Instance
-     WHERE workout_id = ?;`,
+     WHERE workout_type_instance_id = ?;`,
     [workoutId]
   );
 }
@@ -374,7 +379,7 @@ export async function createExercise(
 ) {
   return db.runAsync(
     `INSERT INTO Exercise_Instance (
-      workout_id,
+      workout_type_instance_id,
       exercise_name,
       sets,
       visible_columns,
@@ -387,9 +392,9 @@ export async function createExercise(
 
 export async function getWorkoutIdByExercise(db, exerciseId) {
   return db.getFirstAsync(
-    `SELECT workout_id
+    `SELECT workout_type_instance_id AS workout_id
      FROM Exercise_Instance
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -405,7 +410,7 @@ export async function deleteSetsByExercise(db, exerciseId) {
 export async function deleteExerciseById(db, exerciseId) {
   await db.runAsync(
     `DELETE FROM Exercise_Instance
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -477,9 +482,9 @@ export async function updateExerciseSetCount(db, exerciseId) {
      SET sets = (
        SELECT COUNT(*)
        FROM Sets
-       WHERE Sets.exercise_id = Exercise_Instance.exercise_id
+       WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
      )
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -491,11 +496,11 @@ export async function updateExerciseDoneFromSets(db, exerciseId) {
        NOT EXISTS (
          SELECT 1
          FROM Sets
-         WHERE Sets.exercise_id = Exercise_Instance.exercise_id
+         WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
            AND Sets.done = 0
        )
      )
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [exerciseId]
   );
 }
@@ -507,7 +512,7 @@ export async function updateExerciseVisibleColumns(
   await db.runAsync(
     `UPDATE Exercise_Instance
      SET visible_columns = ?
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [JSON.stringify(columns), exerciseId]
   );
 }
@@ -516,7 +521,7 @@ export async function updateExerciseNote(db, { exerciseId, note }) {
   await db.runAsync(
     `UPDATE Exercise_Instance
      SET note = ?
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [note, exerciseId]
   );
 }
@@ -537,11 +542,11 @@ export async function updateExerciseDoneBySet(db, setId) {
        NOT EXISTS (
          SELECT 1
          FROM Sets
-         WHERE Sets.exercise_id = Exercise_Instance.exercise_id
+         WHERE Sets.exercise_id = Exercise_Instance.exercise_instance_id
            AND Sets.done = 0
        )
      )
-     WHERE exercise_id = (
+     WHERE exercise_instance_id = (
        SELECT exercise_id
        FROM Sets
        WHERE sets_id = ?
@@ -557,7 +562,7 @@ export async function updateWorkoutDoneFromExercises(db, workoutId) {
        NOT EXISTS (
          SELECT 1
          FROM Exercise_Instance
-         WHERE Exercise_Instance.workout_id = Workout_Type_Instance.workout_id
+         WHERE Exercise_Instance.workout_type_instance_id = Workout_Type_Instance.workout_id
            AND Exercise_Instance.done = 0
        )
      )
@@ -568,9 +573,9 @@ export async function updateWorkoutDoneFromExercises(db, workoutId) {
 
 export async function getExerciseAndWorkoutBySetId(db, setId) {
   return db.getFirstAsync(
-    `SELECT s.exercise_id, e.workout_id
+    `SELECT s.exercise_id, e.workout_type_instance_id AS workout_id
      FROM Sets s
-     JOIN Exercise_Instance e ON e.exercise_id = s.exercise_id
+     JOIN Exercise_Instance e ON e.exercise_instance_id = s.exercise_id
      WHERE s.sets_id = ?;`,
     [setId]
   );
@@ -679,7 +684,7 @@ export async function updateExerciseDone(db, { exerciseId, done }) {
   await db.runAsync(
     `UPDATE Exercise_Instance
      SET done = ?
-     WHERE exercise_id = ?;`,
+     WHERE exercise_instance_id = ?;`,
     [done ? 1 : 0, exerciseId]
   );
 }
@@ -688,9 +693,9 @@ export async function deleteSetsByWorkout(db, workoutId) {
   await db.runAsync(
     `DELETE FROM Sets
      WHERE exercise_id IN (
-       SELECT exercise_id
+       SELECT exercise_instance_id
        FROM Exercise_Instance
-       WHERE workout_id = ?
+       WHERE workout_type_instance_id = ?
      );`,
     [workoutId]
   );
@@ -699,7 +704,7 @@ export async function deleteSetsByWorkout(db, workoutId) {
 export async function deleteExercisesByWorkout(db, workoutId) {
   await db.runAsync(
     `DELETE FROM Exercise_Instance
-     WHERE workout_id = ?;`,
+     WHERE workout_type_instance_id = ?;`,
     [workoutId]
   );
 }

--- a/src/Repository/workoutRepository.js
+++ b/src/Repository/workoutRepository.js
@@ -4,7 +4,7 @@ export async function getWorkoutHierarchyIds(db, workoutId) {
         d.day_id,
         d.microcycle_id,
         mc.mesocycle_id
-     FROM Workout w
+     FROM Workout_Type_Instance w
      JOIN Day d ON d.day_id = w.day_id
      JOIN Microcycle mc ON mc.microcycle_id = d.microcycle_id
      WHERE w.workout_id = ?;`,
@@ -18,8 +18,9 @@ export async function getWorkoutPageMetadata(db, workoutId) {
         d.program_id,
         d.Weekday AS day,
         w.date,
-        w.label AS workout_label
-     FROM Workout w
+        w.workout_type,
+        COALESCE(w.label, w.workout_type) AS workout_label
+     FROM Workout_Type_Instance w
      JOIN Day d ON d.day_id = w.day_id
      WHERE w.workout_id = ?;`,
     [workoutId]
@@ -46,7 +47,7 @@ export async function getWorkoutTimerState(db, workoutId) {
         original_start_time,
         timer_start,
         elapsed_time
-     FROM Workout
+     FROM Workout_Type_Instance
      WHERE workout_id = ?;`,
     [workoutId]
   );
@@ -54,14 +55,14 @@ export async function getWorkoutTimerState(db, workoutId) {
 
 export async function clearActiveWorkoutFlags(db) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET is_active = 0;`
   );
 }
 
 export async function normalizeActiveWorkoutFlags(db) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET is_active = 0
      WHERE is_active = 1
        AND (timer_start IS NULL OR done = 1);`
@@ -69,7 +70,7 @@ export async function normalizeActiveWorkoutFlags(db) {
 
   const activeWorkouts = await db.getAllAsync(
     `SELECT workout_id
-     FROM Workout
+     FROM Workout_Type_Instance
      WHERE is_active = 1
        AND timer_start IS NOT NULL
        AND done = 0
@@ -84,7 +85,7 @@ export async function normalizeActiveWorkoutFlags(db) {
 
   for (const staleWorkout of staleWorkouts) {
     await db.runAsync(
-      `UPDATE Workout
+      `UPDATE Workout_Type_Instance
        SET is_active = 0
        WHERE workout_id = ?;`,
       [staleWorkout.workout_id]
@@ -94,7 +95,7 @@ export async function normalizeActiveWorkoutFlags(db) {
 
 export async function setWorkoutActiveFlag(db, { workoutId, isActive }) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET is_active = ?
      WHERE workout_id = ?;`,
     [isActive ? 1 : 0, workoutId]
@@ -104,7 +105,7 @@ export async function setWorkoutActiveFlag(db, { workoutId, isActive }) {
 export async function getActiveWorkoutForTracking(db) {
   return db.getFirstAsync(
     `SELECT workout_id
-     FROM Workout
+     FROM Workout_Type_Instance
      WHERE is_active = 1
        AND timer_start IS NOT NULL
        AND done = 0
@@ -117,7 +118,7 @@ export async function persistWorkoutTimerState(
   { workoutId, timerStart, elapsedTime }
 ) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET timer_start = ?,
          elapsed_time = ?
      WHERE workout_id = ?;`,
@@ -127,7 +128,7 @@ export async function persistWorkoutTimerState(
 
 export async function updateWorkoutElapsedTime(db, { workoutId, elapsedTime }) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET elapsed_time = ?
      WHERE workout_id = ?;`,
     [elapsedTime, workoutId]
@@ -137,7 +138,7 @@ export async function updateWorkoutElapsedTime(db, { workoutId, elapsedTime }) {
 export async function getWorkoutOriginalStartTime(db, workoutId) {
   return db.getFirstAsync(
     `SELECT original_start_time
-     FROM Workout
+     FROM Workout_Type_Instance
      WHERE workout_id = ?;`,
     [workoutId]
   );
@@ -145,7 +146,7 @@ export async function getWorkoutOriginalStartTime(db, workoutId) {
 
 export async function setWorkoutOriginalStartTime(db, { workoutId, startTime }) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET original_start_time = ?
      WHERE workout_id = ?;`,
     [startTime, workoutId]
@@ -155,7 +156,7 @@ export async function setWorkoutOriginalStartTime(db, { workoutId, startTime }) 
 export async function getWorkoutStartTimestamp(db, workoutId) {
   return db.getFirstAsync(
     `SELECT start_ts
-     FROM Workout
+     FROM Workout_Type_Instance
      WHERE workout_id = ?;`,
     [workoutId]
   );
@@ -163,7 +164,7 @@ export async function getWorkoutStartTimestamp(db, workoutId) {
 
 export async function setWorkoutStartTimestamp(db, { workoutId, startTs }) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET start_ts = ?
      WHERE workout_id = ?;`,
     [startTs, workoutId]
@@ -175,7 +176,7 @@ export async function stopWorkoutStopwatch(
   { workoutId, durationSeconds }
 ) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET start_ts = NULL,
          duration_seconds = ?
      WHERE workout_id = ?;`,
@@ -185,7 +186,7 @@ export async function stopWorkoutStopwatch(
 
 export async function updateWorkoutDone(db, { workoutId, done }) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET done = ?
      WHERE workout_id = ?;`,
     [done ? 1 : 0, workoutId]
@@ -194,7 +195,7 @@ export async function updateWorkoutDone(db, { workoutId, done }) {
 
 export async function resetWorkoutStateFields(db, workoutId) {
   await db.runAsync(
-    `UPDATE Workout
+    `UPDATE Workout_Type_Instance
      SET done = 0,
          is_active = 0,
          original_start_time = NULL,
@@ -211,9 +212,9 @@ export async function updateDayDoneFromWorkouts(db, dayId) {
      SET done = (
        NOT EXISTS (
          SELECT 1
-         FROM Workout
-         WHERE Workout.day_id = Day.day_id
-           AND Workout.done = 0
+         FROM Workout_Type_Instance
+         WHERE Workout_Type_Instance.day_id = Day.day_id
+           AND Workout_Type_Instance.done = 0
        )
      )
      WHERE day_id = ?;`,
@@ -227,10 +228,10 @@ export async function updateMicrocycleDoneFromWorkouts(db, microcycleId) {
      SET done = (
        NOT EXISTS (
          SELECT 1
-         FROM Workout
-         JOIN Day ON Day.day_id = Workout.day_id
+         FROM Workout_Type_Instance
+         JOIN Day ON Day.day_id = Workout_Type_Instance.day_id
          WHERE Day.microcycle_id = Microcycle.microcycle_id
-           AND Workout.done = 0
+           AND Workout_Type_Instance.done = 0
        )
      )
      WHERE microcycle_id = ?;`,

--- a/src/Services/programService.js
+++ b/src/Services/programService.js
@@ -674,6 +674,7 @@ export async function copyMicrocycleWorkouts(
         const workoutResult = await programRepository.createWorkout(db, {
           date: targetDay.date,
           dayId: targetDay.day_id,
+          workoutType: workout.workout_type,
           label: workout.label,
         });
 
@@ -745,11 +746,15 @@ export async function getDayByDate(db, { programId, date }) {
   return programRepository.getDayByDate(db, { programId, date });
 }
 
-export async function createWorkoutForDay(db, { date, dayId, label }) {
+export async function createWorkoutForDay(
+  db,
+  { date, dayId, workoutType, label }
+) {
   return withTransaction(db, async () => {
     const workout = await programRepository.createWorkout(db, {
       date,
       dayId,
+      workoutType,
       label,
     });
 

--- a/src/Services/programService.js
+++ b/src/Services/programService.js
@@ -464,7 +464,6 @@ export async function createMesocycle(
     for (let week = 1; week <= weeks; week += 1) {
       const microcycleResult = await programRepository.insertMicrocycle(db, {
         mesocycleId: mesocycleResult.lastInsertRowId,
-        programId,
         microcycleNumber: week,
       });
 
@@ -516,7 +515,6 @@ export async function addWeekToMesocycle(db, { mesocycleId, programId }) {
 
     const microcycleResult = await programRepository.insertMicrocycle(db, {
       mesocycleId,
-      programId,
       microcycleNumber: weeks.length + 1,
     });
 

--- a/src/Services/programService.js
+++ b/src/Services/programService.js
@@ -1,4 +1,10 @@
-import { formatDate, parseCustomDate } from "../Utils/dateUtils";
+import {
+  formatDate,
+  normalizeIsoDateString,
+  normalizeLocalDateString,
+  parseCustomDate,
+} from "../Utils/dateUtils";
+import { supabase } from "../Database/supaBaseClient";
 import {
   programRepository,
   runningRepository,
@@ -17,9 +23,311 @@ const WEEK_DAYS = [
   "Saturday",
   "Sunday",
 ];
+const PROGRAM_CLOUD_TABLE = "Program";
+const PROGRAM_STATUS_VALUES = new Set(["COMPLETE", "ACTIVE", "NOT_STARTED"]);
+const PROGRAM_CLOUD_SYNC_SELECT =
+  "id, user_id, local_program_id, program_name, start_date, status";
+
+let activeProgramSyncPromise = null;
 
 function formatDisplayNumber(value) {
   return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function normalizeProgramName(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function normalizeProgramStartDate(value) {
+  return normalizeLocalDateString(value);
+}
+
+function normalizeProgramStartDateForCloud(value) {
+  return normalizeIsoDateString(value);
+}
+
+function normalizeProgramStatus(value) {
+  const normalizedStatus =
+    typeof value === "string" ? value.trim().toUpperCase() : "";
+
+  return PROGRAM_STATUS_VALUES.has(normalizedStatus)
+    ? normalizedStatus
+    : "NOT_STARTED";
+}
+
+function getComparableProgramSnapshot(program) {
+  return {
+    program_name: normalizeProgramName(program?.program_name),
+    start_date: normalizeProgramStartDate(program?.start_date),
+    status: normalizeProgramStatus(program?.status),
+  };
+}
+
+function areComparableProgramsEqual(leftProgram, rightProgram) {
+  const leftSnapshot = getComparableProgramSnapshot(leftProgram);
+  const rightSnapshot = getComparableProgramSnapshot(rightProgram);
+
+  return (
+    leftSnapshot.program_name === rightSnapshot.program_name &&
+    leftSnapshot.start_date === rightSnapshot.start_date &&
+    leftSnapshot.status === rightSnapshot.status
+  );
+}
+
+function buildCloudProgramPayload(localProgram, userId) {
+  return {
+    user_id: userId,
+    local_program_id: localProgram.program_id,
+    program_name: normalizeProgramName(localProgram.program_name),
+    start_date: normalizeProgramStartDateForCloud(localProgram.start_date),
+    status: normalizeProgramStatus(localProgram.status),
+  };
+}
+
+function parseCloudProgramId(value) {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+async function getAuthenticatedUserId() {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error) {
+    throw error;
+  }
+
+  return data.session?.user?.id ?? null;
+}
+
+async function processQueuedProgramDeletes(db, userId) {
+  const queuedDeletes = await programRepository.getQueuedProgramDeletes(db);
+  let deletedCount = 0;
+
+  for (const queuedDelete of queuedDeletes) {
+    const { error } = await supabase
+      .from(PROGRAM_CLOUD_TABLE)
+      .delete()
+      .eq("id", queuedDelete.cloud_program_id)
+      .eq("user_id", userId);
+
+    if (error) {
+      throw error;
+    }
+
+    await programRepository.deleteQueuedProgramDelete(
+      db,
+      queuedDelete.program_sync_delete_id
+    );
+    deletedCount += 1;
+  }
+
+  return deletedCount;
+}
+
+async function uploadDirtyPrograms(db, userId) {
+  const localPrograms = await programRepository.getProgramsForCloudSync(db);
+  let uploadedCount = 0;
+
+  for (const localProgram of localPrograms) {
+    if (Number(localProgram.needs_sync) !== 1) {
+      continue;
+    }
+
+    const payload = buildCloudProgramPayload(localProgram, userId);
+
+    if (!payload.start_date) {
+      continue;
+    }
+
+    if (localProgram.cloud_program_id) {
+      const { data: updatedProgram, error: updateError } = await supabase
+        .from(PROGRAM_CLOUD_TABLE)
+        .update({
+          program_name: payload.program_name,
+          start_date: payload.start_date,
+          status: payload.status,
+        })
+        .eq("id", localProgram.cloud_program_id)
+        .eq("user_id", userId)
+        .select("id")
+        .maybeSingle();
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      let cloudProgramId = parseCloudProgramId(updatedProgram?.id);
+
+      if (cloudProgramId === null) {
+        const { data: insertedProgram, error: insertError } = await supabase
+          .from(PROGRAM_CLOUD_TABLE)
+          .insert(payload)
+          .select("id")
+          .single();
+
+        if (insertError) {
+          throw insertError;
+        }
+
+        cloudProgramId = parseCloudProgramId(insertedProgram?.id);
+      }
+
+      if (cloudProgramId === null) {
+        throw new Error("Could not resolve cloud program id after update.");
+      }
+
+      await programRepository.markProgramSynced(db, {
+        programId: localProgram.program_id,
+        cloudProgramId,
+      });
+      uploadedCount += 1;
+      continue;
+    }
+
+    const { data: syncedProgram, error: syncError } = await supabase
+      .from(PROGRAM_CLOUD_TABLE)
+      .upsert(payload, {
+        onConflict: "user_id,local_program_id",
+      })
+      .select("id")
+      .single();
+
+    if (syncError) {
+      throw syncError;
+    }
+
+    const cloudProgramId = parseCloudProgramId(syncedProgram?.id);
+
+    if (cloudProgramId === null) {
+      throw new Error("Could not resolve cloud program id after insert.");
+    }
+
+    await programRepository.markProgramSynced(db, {
+      programId: localProgram.program_id,
+      cloudProgramId,
+    });
+    uploadedCount += 1;
+  }
+
+  return uploadedCount;
+}
+
+async function reconcileProgramsFromCloud(db, userId) {
+  const { data: cloudPrograms, error } = await supabase
+    .from(PROGRAM_CLOUD_TABLE)
+    .select(PROGRAM_CLOUD_SYNC_SELECT)
+    .eq("user_id", userId)
+    .order("start_date", { ascending: false })
+    .order("id", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  const localPrograms = await programRepository.getProgramsForCloudSync(db);
+  const localProgramsByCloudId = new Map();
+
+  for (const localProgram of localPrograms) {
+    const cloudProgramId = parseCloudProgramId(localProgram.cloud_program_id);
+
+    if (cloudProgramId !== null) {
+      localProgramsByCloudId.set(cloudProgramId, localProgram);
+    }
+  }
+
+  let downloadedCount = 0;
+
+  await withTransaction(db, async () => {
+    for (const cloudProgram of cloudPrograms ?? []) {
+      const cloudProgramId = parseCloudProgramId(cloudProgram.id);
+      const comparableCloudProgram = getComparableProgramSnapshot(cloudProgram);
+
+      if (cloudProgramId === null || !comparableCloudProgram.start_date) {
+        continue;
+      }
+
+      const localProgram = localProgramsByCloudId.get(cloudProgramId);
+
+      if (!localProgram) {
+        const result = await programRepository.createProgramFromCloud(db, {
+          cloudProgramId,
+          programName: comparableCloudProgram.program_name,
+          startDate: comparableCloudProgram.start_date,
+          status: comparableCloudProgram.status,
+        });
+
+        localProgramsByCloudId.set(cloudProgramId, {
+          program_id: result.lastInsertRowId,
+          cloud_program_id: cloudProgramId,
+          ...comparableCloudProgram,
+          needs_sync: 0,
+        });
+        downloadedCount += 1;
+        continue;
+      }
+
+      if (Number(localProgram.needs_sync) === 1) {
+        continue;
+      }
+
+      if (areComparableProgramsEqual(localProgram, comparableCloudProgram)) {
+        continue;
+      }
+
+      await programRepository.updateProgramFromCloud(db, {
+        programId: localProgram.program_id,
+        cloudProgramId,
+        programName: comparableCloudProgram.program_name,
+        startDate: comparableCloudProgram.start_date,
+        status: comparableCloudProgram.status,
+      });
+
+      localProgramsByCloudId.set(cloudProgramId, {
+        ...localProgram,
+        cloud_program_id: cloudProgramId,
+        ...comparableCloudProgram,
+        needs_sync: 0,
+      });
+      downloadedCount += 1;
+    }
+  });
+
+  return downloadedCount;
+}
+
+async function syncProgramsWithCloudInternal(db) {
+  const userId = await getAuthenticatedUserId();
+
+  if (!userId) {
+    return {
+      changed: false,
+      deletedCount: 0,
+      downloadedCount: 0,
+      uploadedCount: 0,
+    };
+  }
+
+  const deletedCount = await processQueuedProgramDeletes(db, userId);
+  const uploadedCount = await uploadDirtyPrograms(db, userId);
+  const downloadedCount = await reconcileProgramsFromCloud(db, userId);
+
+  return {
+    changed: deletedCount > 0 || uploadedCount > 0 || downloadedCount > 0,
+    deletedCount,
+    downloadedCount,
+    uploadedCount,
+  };
+}
+
+function syncProgramsInBackground(db) {
+  void syncProgramsWithCloud(db).catch((error) => {
+    console.error("Program cloud sync failed:", error);
+  });
 }
 
 function calculateBrzyckiOneRepMax(weight, reps) {
@@ -251,8 +559,21 @@ async function buildWorkoutPreview(db, workout) {
   };
 }
 
+export async function syncProgramsWithCloud(db) {
+  if (activeProgramSyncPromise) {
+    return activeProgramSyncPromise;
+  }
+
+  activeProgramSyncPromise = syncProgramsWithCloudInternal(db).finally(() => {
+    activeProgramSyncPromise = null;
+  });
+
+  return activeProgramSyncPromise;
+}
+
 export async function createProgram(db, { programName, startDate, status }) {
   await programRepository.createProgram(db, { programName, startDate, status });
+  syncProgramsInBackground(db);
 }
 
 export async function getProgramsOverview(db) {
@@ -312,10 +633,12 @@ export async function setProgramBestExerciseSelection(
 
 export async function updateProgramStatus(db, { programId, status }) {
   await programRepository.updateProgramStatus(db, { programId, status });
+  syncProgramsInBackground(db);
 }
 
 export async function updateProgramName(db, { programId, programName }) {
   await programRepository.updateProgramName(db, { programId, programName });
+  syncProgramsInBackground(db);
 }
 
 export async function getProgramDayCount(db, programId) {
@@ -397,6 +720,18 @@ export async function getProgramExerciseBests(db, programId) {
 
 export async function deleteProgram(db, programId) {
   await withTransaction(db, async () => {
+    const syncMetadata = await programRepository.getProgramSyncMetadata(
+      db,
+      programId
+    );
+
+    if (syncMetadata?.cloud_program_id) {
+      await programRepository.queueProgramDeleteSync(db, {
+        cloudProgramId: syncMetadata.cloud_program_id,
+        deletedAt: new Date().toISOString(),
+      });
+    }
+
     await programRepository.deleteSetsByProgram(db, programId);
     await programRepository.deleteExercisesByProgram(db, programId);
     await programRepository.deleteRunsByProgram(db, programId);
@@ -412,6 +747,8 @@ export async function deleteProgram(db, programId) {
     await programRepository.deleteMesocyclesByProgram(db, programId);
     await programRepository.deleteProgramById(db, programId);
   });
+
+  syncProgramsInBackground(db);
 }
 
 export async function createMesocycle(

--- a/src/Services/programService.js
+++ b/src/Services/programService.js
@@ -220,11 +220,11 @@ async function buildWorkoutPreview(db, workout) {
     const setsByExerciseId = {};
 
     for (const set of sets) {
-      if (!setsByExerciseId[set.exercise_id]) {
-        setsByExerciseId[set.exercise_id] = [];
+      if (!setsByExerciseId[set.exercise_instance_id]) {
+        setsByExerciseId[set.exercise_instance_id] = [];
       }
 
-      setsByExerciseId[set.exercise_id].push(set);
+      setsByExerciseId[set.exercise_instance_id].push(set);
     }
 
     return {

--- a/src/Services/weightliftingService.js
+++ b/src/Services/weightliftingService.js
@@ -90,24 +90,26 @@ function normalizeExerciseCatalogEntries(entries) {
   const exerciseMap = new Map();
 
   for (const entry of entries) {
+    const rawName = entry?.name ?? entry?.exercise_name;
     const normalizedName =
-      typeof entry?.exercise_name === "string" ? entry.exercise_name.trim() : "";
+      typeof rawName === "string" ? rawName.trim() : "";
+    const normalizedNickname =
+      typeof entry?.nickname === "string" && entry.nickname.trim() !== ""
+        ? entry.nickname.trim()
+        : null;
 
     if (!normalizedName) {
       continue;
     }
 
     exerciseMap.set(normalizedName.toLocaleLowerCase(), {
-      exercise_name: normalizedName,
-      primary_muscle_group_count:
-        Number(entry?.primary_muscle_group_count) || 0,
-      secondary_muscle_group_count:
-        Number(entry?.secondary_muscle_group_count) || 0,
+      name: normalizedName,
+      nickname: normalizedNickname,
     });
   }
 
   return [...exerciseMap.values()].sort((left, right) =>
-    left.exercise_name.localeCompare(right.exercise_name, undefined, {
+    left.name.localeCompare(right.name, undefined, {
       sensitivity: "base",
     })
   );
@@ -120,11 +122,8 @@ function areExerciseCatalogEntriesEqual(left, right) {
 
   for (let index = 0; index < left.length; index += 1) {
     if (
-      left[index].exercise_name !== right[index].exercise_name ||
-      left[index].primary_muscle_group_count !==
-        right[index].primary_muscle_group_count ||
-      left[index].secondary_muscle_group_count !==
-        right[index].secondary_muscle_group_count
+      left[index].name !== right[index].name ||
+      left[index].nickname !== right[index].nickname
     ) {
       return false;
     }
@@ -171,7 +170,11 @@ function buildExerciseActivationCounts(exercises, activations) {
       const counts = activationMap.get(exercise.id);
 
       return {
-        exercise_name: exercise.name,
+        name: exercise.name,
+        nickname:
+          typeof exercise.nickname === "string" && exercise.nickname.trim() !== ""
+            ? exercise.nickname.trim()
+            : null,
         primary_muscle_group_count: counts?.primary.size ?? 0,
         secondary_muscle_group_count: counts?.secondary.size ?? 0,
       };
@@ -384,6 +387,15 @@ async function getSelectedProgramBestExerciseNames(db, programId) {
   );
 }
 
+function mapExerciseCatalogForDisplay(entries) {
+  return entries.map((entry) => ({
+    exercise_name: entry.name,
+    nickname: entry.nickname,
+    primary_muscle_group_count: Number(entry.primary_muscle_group_count) || 0,
+    secondary_muscle_group_count: Number(entry.secondary_muscle_group_count) || 0,
+  }));
+}
+
 export async function getExerciseStorage(db) {
   return weightliftingRepository.getExerciseStorage(db);
 }
@@ -392,38 +404,88 @@ export async function createExerciseStorage(db, exerciseName) {
   await weightliftingRepository.createExerciseStorage(db, exerciseName);
 }
 
+export async function getExerciseLibraryEntries(db) {
+  const localExerciseRows = await weightliftingRepository.getExerciseStorage(db);
+  const localExercises = normalizeExerciseCatalogEntries(localExerciseRows);
+
+  if (localExercises.length === 0) {
+    return [];
+  }
+
+  try {
+    const { data: exerciseRows, error: exerciseError } = await supabase
+      .from(EXERCISE_LIBRARY_TABLE)
+      .select(
+        `${EXERCISE_LIBRARY_ID_COLUMN}, ${EXERCISE_LIBRARY_NAME_COLUMN}, nickname`
+      )
+      .in(
+        EXERCISE_LIBRARY_NAME_COLUMN,
+        localExercises.map((exercise) => exercise.name)
+      )
+      .order(EXERCISE_LIBRARY_NAME_COLUMN, { ascending: true });
+
+    if (exerciseError) {
+      throw exerciseError;
+    }
+
+    const exerciseIds = (exerciseRows ?? [])
+      .map((row) => row?.[EXERCISE_LIBRARY_ID_COLUMN])
+      .filter((id) => id !== null && id !== undefined);
+    let activationRows = [];
+
+    if (exerciseIds.length > 0) {
+      const { data, error } = await supabase
+        .from(MUSCLE_ACTIVATION_TABLE)
+        .select("exercise_id, muscle_id, activation_level")
+        .in("exercise_id", exerciseIds);
+
+      if (error) {
+        throw error;
+      }
+
+      activationRows = data ?? [];
+    }
+
+    const cloudExercisesWithCounts = buildExerciseActivationCounts(
+      exerciseRows ?? [],
+      activationRows
+    );
+    const cloudExerciseMap = new Map(
+      cloudExercisesWithCounts.map((exercise) => [
+        exercise.name.toLocaleLowerCase(),
+        exercise,
+      ])
+    );
+
+    return mapExerciseCatalogForDisplay(
+      localExercises.map((exercise) => ({
+        ...exercise,
+        primary_muscle_group_count:
+          cloudExerciseMap.get(exercise.name.toLocaleLowerCase())
+            ?.primary_muscle_group_count ?? 0,
+        secondary_muscle_group_count:
+          cloudExerciseMap.get(exercise.name.toLocaleLowerCase())
+            ?.secondary_muscle_group_count ?? 0,
+      }))
+    );
+  } catch (_error) {
+    return mapExerciseCatalogForDisplay(localExercises);
+  }
+}
+
 export async function syncExerciseLibraryFromCloud(db) {
   const { data: exerciseRows, error: exerciseError } = await supabase
     .from(EXERCISE_LIBRARY_TABLE)
-    .select(`${EXERCISE_LIBRARY_ID_COLUMN}, ${EXERCISE_LIBRARY_NAME_COLUMN}`)
+    .select(
+      `${EXERCISE_LIBRARY_ID_COLUMN}, ${EXERCISE_LIBRARY_NAME_COLUMN}, nickname`
+    )
     .order(EXERCISE_LIBRARY_NAME_COLUMN, { ascending: true });
 
   if (exerciseError) {
     throw exerciseError;
   }
 
-  const exerciseIds = (exerciseRows ?? [])
-    .map((row) => row?.[EXERCISE_LIBRARY_ID_COLUMN])
-    .filter((id) => id !== null && id !== undefined);
-  let activationRows = [];
-
-  if (exerciseIds.length > 0) {
-    const { data, error } = await supabase
-      .from(MUSCLE_ACTIVATION_TABLE)
-      .select("exercise_id, muscle_id, activation_level")
-      .in("exercise_id", exerciseIds);
-
-    if (error) {
-      throw error;
-    }
-
-    activationRows = data ?? [];
-  }
-
-  const cloudExercises = buildExerciseActivationCounts(
-    exerciseRows ?? [],
-    activationRows
-  );
+  const cloudExercises = normalizeExerciseCatalogEntries(exerciseRows ?? []);
   const localExerciseRows = await weightliftingRepository.getExerciseStorage(db);
   const localExercises = normalizeExerciseCatalogEntries(localExerciseRows);
 

--- a/src/Services/weightliftingService.js
+++ b/src/Services/weightliftingService.js
@@ -769,10 +769,10 @@ export async function getWorkoutExercises(db, workoutId) {
 
   const setsByExercise = {};
   for (const set of sets) {
-    if (!setsByExercise[set.exercise_id]) {
-      setsByExercise[set.exercise_id] = [];
+    if (!setsByExercise[set.exercise_instance_id]) {
+      setsByExercise[set.exercise_instance_id] = [];
     }
-    setsByExercise[set.exercise_id].push(set);
+    setsByExercise[set.exercise_instance_id].push(set);
   }
 
   return exercises.map((exercise) => {
@@ -897,7 +897,7 @@ export async function deleteSet(db, setId) {
 
     const sets = await weightliftingRepository.getSetIdsByExercise(
       db,
-      set.exercise_id
+      set.exercise_instance_id
     );
     let setNumber = 1;
     for (const row of sets) {
@@ -908,8 +908,8 @@ export async function deleteSet(db, setId) {
       setNumber += 1;
     }
 
-    await weightliftingRepository.updateExerciseSetCount(db, set.exercise_id);
-    await weightliftingRepository.updateExerciseDoneFromSets(db, set.exercise_id);
+    await weightliftingRepository.updateExerciseSetCount(db, set.exercise_instance_id);
+    await weightliftingRepository.updateExerciseDoneFromSets(db, set.exercise_instance_id);
     await weightliftingRepository.updateWorkoutDoneFromExercises(
       db,
       set.workout_id

--- a/src/Sync/ProgramSync.js
+++ b/src/Sync/ProgramSync.js
@@ -1,0 +1,46 @@
+import { AppState } from "react-native";
+import { useEffect, useRef } from "react";
+import { useSQLiteContext } from "expo-sqlite";
+
+import { useAuth } from "../Contexts/AuthContext";
+import { programService } from "../Services";
+
+export default function ProgramSync() {
+  const db = useSQLiteContext();
+  const { isAuthenticated, isAuthLoading } = useAuth();
+  const isSyncingRef = useRef(false);
+
+  const runSync = async () => {
+    if (isAuthLoading || !isAuthenticated || isSyncingRef.current) {
+      return;
+    }
+
+    isSyncingRef.current = true;
+
+    try {
+      await programService.syncProgramsWithCloud(db);
+    } catch (error) {
+      console.error("Program cloud sync failed:", error);
+    } finally {
+      isSyncingRef.current = false;
+    }
+  };
+
+  useEffect(() => {
+    runSync();
+  }, [db, isAuthenticated, isAuthLoading]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      if (nextAppState === "active") {
+        runSync();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [db, isAuthenticated, isAuthLoading]);
+
+  return null;
+}

--- a/src/Utils/dateUtils.js
+++ b/src/Utils/dateUtils.js
@@ -10,6 +10,110 @@ export function formatDate(date) {
   return `${d}.${m}.${y}`;
 }
 
+function isValidDateParts({ day, month, year }) {
+  if (
+    !Number.isInteger(day) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(year)
+  ) {
+    return false;
+  }
+
+  const date = new Date(year, month - 1, day);
+
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
+export function normalizeLocalDateString(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  const localMatch = trimmedValue.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
+
+  if (localMatch) {
+    const [, day, month, year] = localMatch;
+    const dateParts = {
+      day: Number(day),
+      month: Number(month),
+      year: Number(year),
+    };
+
+    if (!isValidDateParts(dateParts)) {
+      return null;
+    }
+
+    return `${day}.${month}.${year}`;
+  }
+
+  const isoMatch = trimmedValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+
+  if (!isoMatch) {
+    return null;
+  }
+
+  const [, year, month, day] = isoMatch;
+  const dateParts = {
+    day: Number(day),
+    month: Number(month),
+    year: Number(year),
+  };
+
+  if (!isValidDateParts(dateParts)) {
+    return null;
+  }
+
+  return `${day}.${month}.${year}`;
+}
+
+export function normalizeIsoDateString(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  const isoMatch = trimmedValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    const dateParts = {
+      day: Number(day),
+      month: Number(month),
+      year: Number(year),
+    };
+
+    if (!isValidDateParts(dateParts)) {
+      return null;
+    }
+
+    return `${year}-${month}-${day}`;
+  }
+
+  const localMatch = trimmedValue.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
+
+  if (!localMatch) {
+    return null;
+  }
+
+  const [, day, month, year] = localMatch;
+  const dateParts = {
+    day: Number(day),
+    month: Number(month),
+    year: Number(year),
+  };
+
+  if (!isValidDateParts(dateParts)) {
+    return null;
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
 export function getTodaysDate() {
   const today = new Date();
   return formatDate(today);


### PR DESCRIPTION
## What changed
This branch packages the current local database alignment work together with the first end-to-end `Program` cloud sync implementation.

Included in this PR:
- local schema alignment fixes for `Microcycle`, `Workout_Type_Instance`, `Exercise`, `Exercise_Instance`, and `Set`
- versioning/changelog updates that belong to those branch-based fixes
- initial cloud sync support for the local `Program` table
- local/cloud date normalization for `Program.start_date`
- sync guidance documenting that `Workout_Type_Instance` is the lowest workout-level cloud sync boundary for future work

## Why it changed
The app needed its local SQLite structure to stay aligned with the current Supabase schema without corrupting device data. On top of that, `Program` needed a first safe cloud sync path so real programs can be tested against the cloud backend before the rest of the hierarchy is synced.

## Impact
- existing local data should migrate forward without dropping user rows
- local `Program` rows can now upload to Supabase and pull down remote-only `Program` rows
- local `Program.start_date` values keep the app's existing `dd.MM.yyyy` format while the cloud receives PostgreSQL-safe `yyyy-MM-dd`
- future workout sync work now has an explicit lower sync boundary: sync children through the owning `Workout_Type_Instance`, not directly from `Set` or `Exercise_Instance`

## Root cause
The previous local model had diverged from the online database shape in several places, and the first `Program` cloud sync attempt surfaced a format mismatch where local date strings like `19.01.2026` were being sent directly to a PostgreSQL `date` column.

## Validation
- `npm run version:status`
- `git diff --check`
- `npx expo export --platform android --output-dir .expo-export-check-android`
- manual verification of date normalization helpers: `19.01.2026 -> 2026-01-19 -> 19.01.2026`

## Notes
This is intentionally the first sync slice only. The PR does not yet sync `Mesocycle`, `Microcycle`, `Day`, `Workout_Type_Instance`, `Exercise_Instance`, or `Set` to the cloud.